### PR TITLE
#33 - Tournament 더미 데이터 추가 및 JSON 파싱 로직 구현

### DIFF
--- a/Kartrider/Application/KartriderApp.swift
+++ b/Kartrider/Application/KartriderApp.swift
@@ -45,6 +45,7 @@ struct KartriderApp: App {
 //                    await StorySeeder.deleteAll(context: context)
 //                    await StorySeeder.seed(context: context)
                     await StorySeeder.seedIfNeeded(context: sharedModelContainer.mainContext)
+                    await TournamentSeeder.seedIfNeeded(context: sharedModelContainer.mainContext)
                     #endif
                 }
         }

--- a/Kartrider/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/Kartrider/Feature/Home/ViewModel/HomeViewModel.swift
@@ -21,7 +21,7 @@ class HomeViewModel: ObservableObject {
     @MainActor
     func loadContents(context: ModelContext) {
         do {
-            contents = try contentRepository.fetchAllContents(context: context)
+            contents = try contentRepository.fetchAllContents(context: context).shuffled()
         } catch {
             print("[ERROR] 컨텐츠 로딩 실패 : \(error)")
         }

--- a/Kartrider/Repository/DTO/TournamentDTO.swift
+++ b/Kartrider/Repository/DTO/TournamentDTO.swift
@@ -6,3 +6,46 @@
 //
 
 import Foundation
+
+//[
+//  {
+//    "meta": {
+//      "title": "최고의 간식 월드컵",
+//      "type": "tournament",
+//      "hashtags": ["간식", "맛있는", "간식최강자"],
+//      "thumbnailName": "snack_thumb"
+//    },
+//    "candidates": [
+//      { "name": "붕어빵" },
+//      { "name": "떡볶이" },
+//      { "name": "치킨" },
+//      { "name": "소떡소떡" }
+//    ]
+//  },
+//  {
+//    "meta": {
+//      "title": "여름 필수템 월드컵",
+//      "type": "tournament",
+//      "hashtags": ["여름", "필수템", "생존템"],
+//      "thumbnailName": "summer_thumb"
+//    },
+//    "candidates": [
+//      { "name": "선풍기" },
+//      { "name": "아이스커피" },
+//      { "name": "모기약" },
+//      { "name": "물놀이 튜브" }
+//    ]
+//  }
+//]
+
+
+struct TournamentJSON: Decodable {
+    let meta: MetaData
+    let candidates: [CandidateData]
+}
+
+struct CandidateData: Decodable {
+    let name: String
+}
+
+

--- a/Kartrider/Repository/JSONParser/TournamentJSONParser.swift
+++ b/Kartrider/Repository/JSONParser/TournamentJSONParser.swift
@@ -1,0 +1,49 @@
+//
+//  TournamentJSONParser.swift
+//  Kartrider
+//
+//  Created by J on 6/2/25.
+//
+
+import Foundation
+import SwiftData
+
+enum TournamentJSONParser {
+    static func loadJSON(named fileName: String) -> Data? {
+        guard let url = Bundle.main.url(forResource: fileName, withExtension: "json") else {
+            print("[ERROR] JSON 파일을 찾을 수 없습니다 - \(fileName)")
+            return nil
+        }
+        return try? Data(contentsOf: url)
+    }
+    
+    static func parseAndInsertTournaments(from jsonData: Data, context: ModelContext) throws {
+        let decoder = JSONDecoder()
+        let tournamentList = try decoder.decode([TournamentJSON].self, from: jsonData)
+        
+        for tournamentJSON in tournamentList {
+            let meta = ContentMeta(
+                title: tournamentJSON.meta.title,
+                summary: tournamentJSON.meta.summary,
+                type: .tournament,
+                hashtags: tournamentJSON.meta.hashtags,
+                thumbnailName: tournamentJSON.meta.thumbnailName
+            )
+            context.insert(meta)
+            
+            let tournament = Tournament(meta: meta)
+            context.insert(tournament)
+            
+            for candidateData in tournamentJSON.candidates {
+                let candidate = Candidate(name: candidateData.name, tournament: tournament)
+                tournament.candidates.append(candidate)
+                context.insert(candidate)
+            }
+        }
+        
+        try context.save()
+        print("[DEBUG] 저장된 Tournament 수: \(try context.fetch(FetchDescriptor<Tournament>()).count)")
+        print("[DEBUG] 저장된 Candidate 수: \(try context.fetch(FetchDescriptor<Candidate>()).count)")
+        print("[DEBUG] 저장된 ContentMeta 수: \(try context.fetch(FetchDescriptor<ContentMeta>()).count)")
+    }
+}

--- a/Kartrider/Repository/Seeder/TournamentSeeder.swift
+++ b/Kartrider/Repository/Seeder/TournamentSeeder.swift
@@ -1,0 +1,40 @@
+//
+//  TournamentSeeder.swift
+//  Kartrider
+//
+//  Created by J on 6/2/25.
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+struct TournamentSeeder {
+    static func seedIfNeeded(context: ModelContext) async {
+        await seed(context: context)
+        print("[INFO] Tournament 시드 완료")
+    }
+
+    static func seed(context: ModelContext) async {
+        guard let jsonData = TournamentJSONParser.loadJSON(named: "dummy_tournament") else {
+            print("[ERROR] Tournament JSON 파일 로드 실패")
+            return
+        }
+
+        do {
+            try TournamentJSONParser.parseAndInsertTournaments(from: jsonData, context: context)
+            print("[INFO] Tournament 데이터 시드 완료")
+        } catch {
+            print("[ERROR] Tournament 파싱 실패: \(error)")
+        }
+    }
+
+    static func printCandidateCount(context: ModelContext) async {
+        do {
+            let count = try context.fetch(FetchDescriptor<Candidate>()).count
+            print("[INFO] 현재 저장된 Candidate 수: \(count)")
+        } catch {
+            print("[ERROR] Candidate 수 확인 실패: \(error)")
+        }
+    }
+}

--- a/Kartrider/Resource/JSON/dummy_tournament.json
+++ b/Kartrider/Resource/JSON/dummy_tournament.json
@@ -1,0 +1,32 @@
+[
+  {
+    "meta": {
+      "title": "최고의 간식 월드컵",
+      "summary": "최고의 간식을 뽑아보는 맛있는 대결!",
+      "type": "tournament",
+      "hashtags": ["간식", "맛있는", "간식최강자"],
+      "thumbnailName": "snack_thumb"
+    },
+    "candidates": [
+      { "name": "붕어빵" },
+      { "name": "떡볶이" },
+      { "name": "치킨" },
+      { "name": "소떡소떡" }
+    ]
+  },
+  {
+    "meta": {
+      "title": "여름 필수템 월드컵",
+      "summary": "여름을 이겨내기 위한 필수템을 골라보세요!",
+      "type": "tournament",
+      "hashtags": ["여름", "필수템", "생존템"],
+      "thumbnailName": "summer_thumb"
+    },
+    "candidates": [
+      { "name": "선풍기" },
+      { "name": "아이스커피" },
+      { "name": "모기약" },
+      { "name": "물놀이 튜브" }
+    ]
+  }
+]


### PR DESCRIPTION
## #️⃣ 관련 이슈
closes #33 

---

## 💻 작업 내용

- dummy_tournament.json 파일 추가
- 토너먼트용 DTO 정의
- TournamentJSONParser 구현
- TournamentSeeder 구현 
- KartriderApp에 시드 로직 연결

---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 


