### PR TITLE
#44 - 토너먼트 종료 시 히스토리 저장 로직 추가

### DIFF
--- a/Kartrider/Feature/Tournament/View/TournamentView.swift
+++ b/Kartrider/Feature/Tournament/View/TournamentView.swift
@@ -32,6 +32,10 @@ struct TournamentView: View {
         .task {
             viewModel.loadTournament(context: context)
         }
+        .onChange(of: viewModel.isFinished) { isFinished in
+            guard isFinished else { return }
+            viewModel.finishTournamentAndSave(context: context)
+        }
     }
     
     @ViewBuilder

--- a/Kartrider/Feature/Tournament/ViewModel/TournamentViewModel.swift
+++ b/Kartrider/Feature/Tournament/ViewModel/TournamentViewModel.swift
@@ -13,10 +13,12 @@ class TournamentViewModel: ObservableObject {
     @Published var currentCandidates: (Candidate, Candidate)?
     @Published var isFinished = false
     @Published var winner: Candidate?
+    @Published var matchHistory: [TournamentStepData] = []
     
-    private let repository: ContentRepositoryProtocol
+    private let contentRepository: ContentRepositoryProtocol
+    private let historyRepository: PlayHistoryRepositoryProtocol
     private let tournamentId: UUID
-    
+    private var tournament: Tournament?
     private var nextRoundCandidates: [Candidate] = []
     private var rounds: [[Candidate]] = []
     private var currentRoundIndex = 0 // 지금 몇 라운드인지 ex. 8강, 4강, 결승
@@ -25,39 +27,36 @@ class TournamentViewModel: ObservableObject {
     var currentRoundDescription: String {
         guard rounds.indices.contains(currentRoundIndex) else { return "" }
         let count = rounds[currentRoundIndex].count
-        let roundText : String
-        
-        switch count {
-        case 2: roundText = "결승"
-        default: roundText = "\(count)강"
-        }
-        
-        
+        let roundText : String = (count == 2) ? "결승" : "\(count)강"
         let matchNumber = currentMatchIndex + 1
         let totalMatches = count / 2
-        
         return "\(roundText)\n\(totalMatches)개의 경기 중 \(matchNumber)번째 경기"
     }
     
-    init(tournamentId: UUID, repository: ContentRepositoryProtocol = ContentRepository()) {
+    init(
+        tournamentId: UUID,
+        contentRepository: ContentRepositoryProtocol = ContentRepository(),
+        historyRepository: PlayHistoryRepositoryProtocol = PlayHistoryRepository()
+    ) {
         self.tournamentId = tournamentId
-        self.repository = repository
+        self.contentRepository = contentRepository
+        self.historyRepository = historyRepository
     }
     
     func loadTournament(context: ModelContext) {
         do {
-            guard let tournament = try repository.fetchTournament(by: tournamentId, context: context) else {
+            guard let tournament = try contentRepository.fetchTournament(by: tournamentId, context: context) else {
                 print("[ERROR] 토너먼트 찾을 수 없음")
                 return
             }
-            
+            self.tournament = tournament
             let shuffled = tournament.candidates.shuffled()
             rounds = [shuffled]
             isFinished = false
             winner = nil
             currentRoundIndex = 0
             currentMatchIndex = 0
-            
+            matchHistory = []
             prepareNextMatch()
         } catch {
             print("[ERROR] 토너먼트 로딩 실패 : \(error)")
@@ -66,7 +65,6 @@ class TournamentViewModel: ObservableObject {
     
     func prepareNextMatch() {
         let currentRound = rounds[currentRoundIndex]
-
         guard currentMatchIndex * 2 + 1 < currentRound.count else {
             // 현재 라운드 끝났으면
             if nextRoundCandidates.count == 1 {
@@ -83,13 +81,26 @@ class TournamentViewModel: ObservableObject {
             }
             return
         }
-
+        
         let a = currentRound[currentMatchIndex * 2]
         let b = currentRound[currentMatchIndex * 2 + 1]
         currentCandidates = (a, b)
     }
     
     func select(_ selected: Candidate) {
+        guard let (a, b) = currentCandidates else { return }
+        
+        // 기록 저장
+        let step = TournamentStepData(
+            round: rounds[currentRoundIndex].count,
+            matchIndex: currentMatchIndex,
+            candidateAText: a.name,
+            candidateBText: b.name,
+            selectedText: selected.name,
+            timestamp: Date()
+        )
+        matchHistory.append(step)
+        
         nextRoundCandidates.append(selected)
         currentMatchIndex += 1
         prepareNextMatch()
@@ -100,6 +111,17 @@ class TournamentViewModel: ObservableObject {
         return round
     }
     
-    
-    
+    func finishTournamentAndSave(context: ModelContext) {
+        guard let winner = winner else { return }
+        do {
+            try historyRepository.saveTournamentHistory(
+                context: context,
+                tournamentId: tournamentId,
+                winner: winner,
+                matchHistory: matchHistory
+            )
+        } catch {
+            print("[ERROR] 토너먼트 히스토리 저장 실패 : \(error)")
+        }
+    }
 }

--- a/Kartrider/Model/History/TournamentStep.swift
+++ b/Kartrider/Model/History/TournamentStep.swift
@@ -10,24 +10,20 @@ import SwiftData
 
 @Model
 class TournamentStep {
-    var round: Int
-    var candidateAId: UUID
-    var candidateBId: UUID
+    var round: Int // 몇 강인지 (8, 4, 2 == 결승 등)
+    var matchIndex: Int // 해당 라운드에서 몇 번째 경기인지
     var candidateAText: String
     var candidateBText: String
-    var selectedCandidateId: UUID
     var selectedText: String
     var timestamp: Date = Date()
 
     @Relationship var history: PlayHistory
 
-    init(round: Int, candidateAId: UUID, candidateBId: UUID, candidateAText: String, candidateBText: String, selectedCandidateId: UUID, selectedText: String, timestamp: Date, history: PlayHistory) {
+    init(round: Int, matchIndex: Int, candidateAText: String, candidateBText: String, selectedText: String, timestamp: Date, history: PlayHistory) {
         self.round = round
-        self.candidateAId = candidateAId
-        self.candidateBId = candidateBId
+        self.matchIndex = matchIndex
         self.candidateAText = candidateAText
         self.candidateBText = candidateBText
-        self.selectedCandidateId = selectedCandidateId
         self.selectedText = selectedText
         self.timestamp = timestamp
         self.history = history

--- a/Kartrider/Repository/DTO/PlayHistoryDTO.swift
+++ b/Kartrider/Repository/DTO/PlayHistoryDTO.swift
@@ -1,0 +1,18 @@
+//
+//  PlayHistoryDTO.swift
+//  Kartrider
+//
+//  Created by J on 6/4/25.
+//
+
+import Foundation
+
+struct TournamentStepData: Identifiable {
+    let id = UUID()
+    var round: Int
+    var matchIndex: Int
+    var candidateAText: String
+    var candidateBText: String
+    var selectedText : String
+    var timestamp: Date
+}

--- a/Kartrider/Repository/DTO/TournamentDTO.swift
+++ b/Kartrider/Repository/DTO/TournamentDTO.swift
@@ -48,4 +48,3 @@ struct CandidateData: Decodable {
     let name: String
 }
 
-

--- a/Kartrider/Repository/PlayHistoryRepository.swift
+++ b/Kartrider/Repository/PlayHistoryRepository.swift
@@ -6,7 +6,42 @@
 //
 
 import Foundation
+import SwiftData
 
-class PlayHistoryRepository {
-
+class PlayHistoryRepository: PlayHistoryRepositoryProtocol {
+    
+    private let contentRepository: ContentRepositoryProtocol
+    
+    init(contentRepository: ContentRepositoryProtocol = ContentRepository()) {
+        self.contentRepository = contentRepository
+    }
+    
+    func saveTournamentHistory(
+        context: ModelContext,
+        tournamentId: UUID,
+        winner: Candidate,
+        matchHistory: [TournamentStepData]
+    ) throws {
+        guard let tournament = try contentRepository.fetchTournament(by: tournamentId, context: context) else { return }
+        
+        let history = PlayHistory(content: tournament.meta)
+        history.endedAt = Date()
+        history.winningCandidateId = winner.id
+        context.insert(history)
+        
+        for step in matchHistory {
+            let tournamentStep = TournamentStep(
+                round: step.round,
+                matchIndex: step.matchIndex,
+                candidateAText: step.candidateAText,
+                candidateBText: step.candidateBText,
+                selectedText: step.selectedText,
+                timestamp: step.timestamp,
+                history: history
+            )
+            context.insert(tournamentStep)
+        }
+        
+        try context.save()
+    }
 }

--- a/Kartrider/Repository/Protocol/PlayHistoryRepositoryProtocol.swift
+++ b/Kartrider/Repository/Protocol/PlayHistoryRepositoryProtocol.swift
@@ -6,9 +6,13 @@
 //
 
 import Foundation
+import SwiftData
 
 protocol PlayHistoryRepositoryProtocol {
-    func fetchAllHistories() throws -> [PlayHistory]
-    func fetchHistory(for contentId: UUID) throws -> PlayHistory?
-    func saveStoryHistory(for contentId: UUID, steps: [StoryStep]) throws
+    func saveTournamentHistory(
+        context: ModelContext,
+        tournamentId: UUID,
+        winner: Candidate,
+        matchHistory: [TournamentStepData]
+    ) throws
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
closes #44 

---

## 💻 작업 내용

- 토너먼트 종로 후, 사용자의 선택 흐름을 PlayHistory에 저장하도록 기능 구현
- TournamentStepData를 기반으로 각 매치를 기록
- PlayHistoryRepository를 통해 SwiftData에 저장
- 저장 시점은 TournamentView의 .onChange(of: isFinished) 에서 트리거되어 구현
- TournamentViewModel에서 select() 시 선택 데이터 기록
- TournamentViewModel에서 finishedTournamentAndSave() 로 저장 위임

---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성 


