### PR TITLE
#46 - Tournament TTS 삽입

### DIFF
--- a/Kartrider/Feature/Tournament/View/TournamentMatchView.swift
+++ b/Kartrider/Feature/Tournament/View/TournamentMatchView.swift
@@ -13,6 +13,7 @@ struct TournamentMatchView: View {
     let b: String
     let onSelectA: () -> Void
     let onSelectB: () -> Void
+    var buttonDisabled: Bool = false
     
     var body: some View {
         VStack(spacing: 18) {
@@ -20,16 +21,12 @@ struct TournamentMatchView: View {
             
             VStack(spacing: 16) {
                 DecisionBoxView(text: a, storyChoiceOption: StoryChoiceOption.a, action: onSelectA)
+                    .disabled(buttonDisabled)
                 DecisionBoxView(text: b, storyChoiceOption: StoryChoiceOption.b, action: onSelectB)
+                    .disabled(buttonDisabled)
             }
             
             Spacer()
-            
-            Text("다음 컨텐츠가 10초 후에 재생됩니다.")
-                .font(.callout)
-                .foregroundColor(Color.textSecondary)
-            
-            
         }
     }
 }

--- a/Kartrider/Feature/Tournament/View/TournamentView.swift
+++ b/Kartrider/Feature/Tournament/View/TournamentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import SwiftData
 
 struct TournamentView: View {
+    @EnvironmentObject private var ttsManager: TTSManager
     @EnvironmentObject private var coordinator: NavigationCoordinator
     @Environment(\.modelContext) private var context
     @StateObject private var viewModel: TournamentViewModel
@@ -27,10 +28,17 @@ struct TournamentView: View {
             navStyle: .play(title: title),
             onTapLeft: { coordinator.pop() }
         ) {
-            contentBody
+            VStack(spacing: 16) {
+                contentBody
+                statusIndicator
+                retryButton
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.top, 40)
         }
         .task {
             viewModel.loadTournament(context: context)
+            speakCurrentMatch()
         }
         .onChange(of: viewModel.isFinished) { isFinished in
             guard isFinished else { return }
@@ -38,30 +46,79 @@ struct TournamentView: View {
         }
     }
     
+    // MARK: - View Sections
+    
     @ViewBuilder
     private var contentBody: some View {
-        VStack(spacing: 24) {
-            if viewModel.isFinished {
-                if let winner = viewModel.winner {
-                    TournamentResultView(winner: winner.name) {
-                        coordinator.popToRoot()
-                    }
-                }
+        if viewModel.isFinished, let winner = viewModel.winner {
+            TournamentResultView(winner: winner.name) {
+                coordinator.popToRoot()
             }
-            else if let (a, b) = viewModel.currentCandidates {
-                TournamentMatchView(
-                    roundDescription: viewModel.currentRoundDescription,
-                    a: a.name,
-                    b: b.name,
-                    onSelectA: { viewModel.select(a) },
-                    onSelectB: { viewModel.select(b) }
-                )
-            } else {
-                ProgressView()
+            .task(id: viewModel.winner?.id) {
+                guard let name = viewModel.winner?.name else { return }
+                await ttsManager.stop()
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                await ttsManager.speakSequentially("최종 우승자는 \(winner.name)입니다")
             }
+        } else if let (a, b) = viewModel.currentCandidates {
+            TournamentMatchView(
+                roundDescription: viewModel.currentRoundDescription,
+                a: a.name,
+                b: b.name,
+                onSelectA: { handleSelection(a) },
+                onSelectB: { handleSelection(b) },
+                buttonDisabled: ttsManager.isSpeaking
+            )
+        } else {
+            ProgressView()
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.top, 40)
+    }
+    
+    private var statusIndicator: some View {
+        Text(ttsManager.isSpeaking ? "읽는 중..." : "정지됨")
+            .font(.caption)
+            .foregroundColor(.gray)
+    }
+    
+    private var retryButton: some View {
+        Button("선택지 다시 듣기", action: speakOnlyChoices)
+            .padding(.top, 8)
+    }
+}
+
+extension TournamentView {
+    // MARK: - TTS Helpers
+    private func handleSelection(_ candidate: Candidate) {
+        
+        Task {
+            await ttsManager.stop()
+            await speakSelectedChoice(candidate)
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            
+            viewModel.select(candidate)
+            speakCurrentMatch()
+        }
+    }
+    
+    private func speakCurrentMatch() {
+        guard let (a, b) = viewModel.currentCandidates else { return }
+        Task {
+            await ttsManager.speakSequentially(viewModel.currentRoundDescription)
+            await ttsManager.speakSequentially("A. \(a.name)")
+            await ttsManager.speakSequentially("B. \(b.name)")
+        }
+    }
+    
+    private func speakOnlyChoices() {
+        guard let (a, b) = viewModel.currentCandidates else { return }
+        Task {
+            await ttsManager.speakSequentially("A. \(a.name)")
+            await ttsManager.speakSequentially("B. \(b.name)")
+        }
+    }
+    
+    private func speakSelectedChoice(_ candidate: Candidate) async {
+        await ttsManager.speakSequentially("\(candidate.name) 선택")
     }
 }
 

--- a/Kartrider/Navigation/AppNavigationView.swift
+++ b/Kartrider/Navigation/AppNavigationView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AppNavigationView: View {
 
     @ObservedObject private var coordinator = NavigationCoordinator()
+    @StateObject private var ttsManager = TTSManager()
 
     var body: some View {
         NavigationStack(path: $coordinator.paths) {
@@ -27,7 +28,9 @@ struct AppNavigationView: View {
                 case .historyTimeline: HistoryTimelineView()
                 }
             }
-        }.environmentObject(coordinator)
+        }
+        .environmentObject(coordinator)
+        .environmentObject(ttsManager)
     }
 }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
closes #46 

---

## 💻 작업 내용

- TournamentView에 TTS(TTSManager) 연동
- 매 라운드마다 라운드 설명 + 후보자 이름을 자동 낭독
- 사용자가 버튼 클릭 시 선택 후보 TTS로 피드백 제공
- 임의로 "선택지 다시 듣기" 버튼 추가 (선택지만 재낭독)
- 최종 우승자 결과 페이지 진입 시 우승자 낭독
- TTS가 재생 중일 때는 버튼 비활성화(disabled) 처리
- 선택된 후보 버튼 색상 반영 (선택 UI 피드백 개선)

---

## 📝 코드 설명

1. TTSManager 연동
   - TournamentView에서 `@EnviromentObject private var ttsManager` 로 주입 받음
   - `speakSequentially(_:)` 메서드를 통해 순차적으로 음성 읽기를 진행함
   - 재생 중 여부를 판단하기 위해  `ttsManager.isSpeaking` 상태값 사용함
2. TournamentView 내 TTS 흐름
   - `.task` 에서 토너믄트 로드 후 `speakCurrentMatch()` 호출 -> 라운드 설명 및 후보자 이름 낭독
        ```Swift
        viewModel.loadTournament(context: context)
        speakCurrentMatch()
        ```
    - 사용자가 버튼을 누르면 handleSelection(_:) 실행
        ```Swift
        Task {
            await ttsManager.stop() // 이전 읽기 중단
            await speakSelectedChoice(candidate) // 선택한 후보 낭독
            try? await Task.sleep(nanoseconds: 200_000_000) // 잠시 멈춤
            viewModel.select(candidate) // 선택 반영
            speakCurrentMatch() // 다음 라운드 낭독
        }
        ```
    - 마지막 결과 화면 진입 시, `.task(id:)` 를 활용하여 우승자 낭독
        ```Swift
        .task(id: viewModel.winner?.id) {
            await ttsManager.stop()
            try? await Task.sleep(nanoseconds: 300_000_000)
            await ttsManager.speakSequentially("최종 우승자는 \(winner.name)입니다")
        }
        ```
3. 버튼 상태 제어 (.disabled)
   - 니카가 버튼을 disabled 하셨다길래 저도 ㅎㅎ
   - `ttsManager.isSpeaking` 값에 따라 선택 버튼 비활성화
   - `.onChange(of: currentCandidates)`를 통해 라운드가 넘어갈 때 선택 상태 초기화
        ```Swift
        buttonDisabled: ttsManager.isSpeaking
        ```
4. 선택 UI 상태 반영
   - selectedOption: StoryChoiceOption?을 @State로 선언하여 버튼 색상 제어
   - TournamentMatchView → DecisionBoxView로 전달하여 선택 시 색상 반전
        ```Swift
        isSelected: selectedOption == .a
        ```
---

## 💬 TMI
- 사실 View에서 @State 없이 최대한 MVVM 깔끔하게 가져가고 싶었으나, 선택 버튼 색 반영 때문에 어쩔 수 없이 selectedOption을 View에서 직접 관리하게 됨... 단순 UI 변경이니까 봐달라. (당당)
- TTSManager도 ViewModel에서 제어하고 싶었지만, @EnvironmentObject로 넘기자니 초기화 문제가 자꾸 발생해서 결국 View에서 직접 제어하게 됨 (당당)
- ... 이쯤되니 점점 루미에게 코드 리뷰해달라고 할 자신이 사라지고 있음 🫥

---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 


