### PR TITLE
#58 - ending에서 엔딩재생/타이머 플로우 수정 완료

### DIFF
--- a/Kartrider/Feature/Story/ViewModel/StoryViewModel.swift
+++ b/Kartrider/Feature/Story/ViewModel/StoryViewModel.swift
@@ -155,11 +155,11 @@ class StoryViewModel: ObservableObject {
                 let endingNode = story.nodes.first(where: { $0.id == toId })
             {
                 currentNode = endingNode
-                iosConnectManager?.sendStageEnding()
+                iosConnectManager?.sendStageEndingTTS()
                 if !endingNode.text.isEmpty {
-
                     await ttsManager.speakSequentially(endingNode.text)
                 }
+                iosConnectManager?.sendStageEndingTimer()
             } else {
                 errorMessage = "해당 결말을 찾을 수 없습니다"
             }

--- a/Kartrider/Feature/Tournament/View/TournamentView.swift
+++ b/Kartrider/Feature/Tournament/View/TournamentView.swift
@@ -77,7 +77,7 @@ struct TournamentView: View {
                 coordinator.popToRoot()
             }
             .task(id: viewModel.winner?.id) {
-                iosConnectManager.sendStageEnding()
+                iosConnectManager.sendStageEndingTTS()
                 guard let name = viewModel.winner?.name else { return }
                 await ttsManager.stop()
                 try? await Task.sleep(nanoseconds: 300_000_000)

--- a/Kartrider/IosConnectManager.swift
+++ b/Kartrider/IosConnectManager.swift
@@ -156,13 +156,16 @@ class IosConnectManager: NSObject, WCSessionDelegate, ObservableObject {
         }
     }
 
-    func sendStageEnding() {
+    func sendStageEndingTTS() {
+        let message: [String: Any] = [
+            "stage": "ending", "timerStarted": false,
+        ]
         let session = WCSession.default
         if session.isReachable {
-            session.sendMessage(["stage": "ending"], replyHandler: nil)
+            session.sendMessage(message, replyHandler: nil)
         }
     }
-    
+
     func sendStageEndingTimer() {
         let message: [String: Any] = [
             "stage": "ending", "timerStarted": true,

--- a/Pickacha Watch App/WatchFeature/Outro/WatchOutroViewModel.swift
+++ b/Pickacha Watch App/WatchFeature/Outro/WatchOutroViewModel.swift
@@ -25,7 +25,7 @@ class WatchOutroViewModel: ObservableObject {
         guard !isTimerStart else { return }
         isTimerStart = true
         connectManager.timerStarted = true
-        
+
         timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) {
             _ in
             if self.time > 0 {


### PR DESCRIPTION
## #️⃣ 관련 이슈
closes #58 

---

## 💻 작업 내용

- ending stage일때 엔딩 재생중 / 선택 타이머를 구분하는 부분 수정 완료

---

## 📝 코드 설명

IosConnectManager에서 sendStageEnding할 때 TimerStarted를 false, true 두가지로 나눠서 전송하는 것으로 수정(기존에는 true일때만 전송함)

---

## 📁 P.S.
이제 선택되지 않음 플로우를 넣어야하는데.. 약간 쫄리기 때문에 따로 issue랑 branch 파서 하겠숩니다
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 


