### PR TITLE
#80 WatchConnectivity singletone 패턴 적용 - ios

### DIFF
--- a/Kartrider.xcodeproj/project.pbxproj
+++ b/Kartrider.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Kartrider/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 3ZR27WJQYX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -405,7 +405,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Kartrider/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 3ZR27WJQYX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -445,7 +445,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Pickacha Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 3ZR27WJQYX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Pickacha;
@@ -477,7 +477,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Pickacha Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 3ZR27WJQYX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Pickacha;

--- a/Kartrider.xcodeproj/project.pbxproj
+++ b/Kartrider.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Kartrider/Preview Content\"";
-				DEVELOPMENT_TEAM = 3ZR27WJQYX;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -405,7 +405,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Kartrider/Preview Content\"";
-				DEVELOPMENT_TEAM = 3ZR27WJQYX;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -445,7 +445,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Pickacha Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = 3ZR27WJQYX;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Pickacha;
@@ -477,7 +477,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Pickacha Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = 3ZR27WJQYX;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Pickacha;

--- a/Kartrider/Application/KartriderApp.swift
+++ b/Kartrider/Application/KartriderApp.swift
@@ -11,7 +11,6 @@ import SwiftUI
 @main
 struct KartriderApp: App {
 
-    @StateObject private var iosConnectManager = IosConnectManager()
     @StateObject private var seedManager = SeedManager()
 
     var body: some Scene {

--- a/Kartrider/Application/KartriderApp.swift
+++ b/Kartrider/Application/KartriderApp.swift
@@ -18,10 +18,9 @@ struct KartriderApp: App {
             if seedManager.isReady {
                 AppNavigationView()
                     .modelContainer(seedManager.container)
-                    .environmentObject(iosConnectManager)
             } else {
                 LaunchView()
-                    .task{
+                    .task {
                         await seedManager.seedIfNeeded()
                     }
             }

--- a/Kartrider/Feature/Intro/IntroView.swift
+++ b/Kartrider/Feature/Intro/IntroView.swift
@@ -9,14 +9,15 @@ import SwiftUI
 // TODO: 컴포넌트 분리
 struct IntroView: View {
     @Environment(\.modelContext) private var context
-    
+
     @EnvironmentObject private var coordinator: NavigationCoordinator
     // TODO: 객체 ViewModel에서 생성
-    @StateObject private var viewModel: IntroViewModel
+    @StateObject private var introViewModel: IntroViewModel
 
     // TODO: init 제거 -> 어떻게 제거해요? content를 넘겨줘야하는데!!!
     init(content: ContentMeta) {
-        _viewModel = StateObject(wrappedValue: IntroViewModel(content: content))
+        _introViewModel = StateObject(
+            wrappedValue: IntroViewModel(content: content))
     }
 
     var body: some View {
@@ -26,28 +27,31 @@ struct IntroView: View {
         ) {
             VStack(spacing: 16) {
 
-                IntroThumbnailView(content: viewModel.content)
+                IntroThumbnailView(content: introViewModel.content)
 
                 Divider()
                     .frame(width: 360)
 
-                IntroDescriptionView(content: viewModel.content)
+                IntroDescriptionView(content: introViewModel.content)
 
-                OrangeButton(title: "이야기 시작하기") { // TODO: - 로직 vm으로 옮기기
+                OrangeButton(title: "이야기 시작하기") {  // TODO: - 로직 vm으로 옮기기
 
-                    viewModel.sendStageIdle()
+                    introViewModel.sendStageIdle()
 
-                    switch viewModel.content.type {
+                    switch introViewModel.content.type {
                     case .story:
-                        if let startNodeId = viewModel.content.story?.startNodeId {
+                        if let startNodeId = introViewModel.content.story?
+                            .startNodeId
+                        {
                             coordinator.push(
-                                Route.story(viewModel.content))
+                                Route.story(introViewModel.content))
                         } else {
                             print("[ERROR] 스토리가 존재하지 않음")
                         }
                     case .tournament:
-                        if let id = viewModel.content.tournament?.id {
-                            coordinator.push(Route.tournament(viewModel.content))
+                        if let id = introViewModel.content.tournament?.id {
+                            coordinator.push(
+                                Route.tournament(introViewModel.content))
                         } else {
                             print("[ERROR] 토너먼트가 존재하지 않음")
                         }

--- a/Kartrider/Feature/Intro/IntroView.swift
+++ b/Kartrider/Feature/Intro/IntroView.swift
@@ -12,7 +12,6 @@ struct IntroView: View {
     
     @EnvironmentObject private var coordinator: NavigationCoordinator
     // TODO: 객체 ViewModel에서 생성
-    @EnvironmentObject private var iosConnectManager: IosConnectManager
     @StateObject private var viewModel: IntroViewModel
 
     // TODO: init 제거 -> 어떻게 제거해요? content를 넘겨줘야하는데!!!
@@ -36,7 +35,7 @@ struct IntroView: View {
 
                 OrangeButton(title: "이야기 시작하기") { // TODO: - 로직 vm으로 옮기기
 
-                    iosConnectManager.sendStageIdle()
+                    viewModel.sendStageIdle()
 
                     switch viewModel.content.type {
                     case .story:

--- a/Kartrider/Feature/Intro/IntroViewModel.swift
+++ b/Kartrider/Feature/Intro/IntroViewModel.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 class IntroViewModel: ObservableObject {
+    let connectManager = IosConnectManager.shared
+
     @Published var content: ContentMeta
     @Published var hasSentIdle: Bool = false
 
@@ -16,5 +18,9 @@ class IntroViewModel: ObservableObject {
         print(
             "[DEBUG] IntroViewModel 초기화 - 제목 : \(content.title), 타입 : \(content.type)"
         )
+    }
+    
+    func sendStageIdle(){
+        connectManager.sendStageIdle()
     }
 }

--- a/Kartrider/Feature/Intro/IntroViewModel.swift
+++ b/Kartrider/Feature/Intro/IntroViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 class IntroViewModel: ObservableObject {
+
     let connectManager = IosConnectManager.shared
 
     @Published var content: ContentMeta
@@ -19,8 +20,8 @@ class IntroViewModel: ObservableObject {
             "[DEBUG] IntroViewModel 초기화 - 제목 : \(content.title), 타입 : \(content.type)"
         )
     }
-    
-    func sendStageIdle(){
+
+    func sendStageIdle() {
         connectManager.sendStageIdle()
     }
 }

--- a/Kartrider/Feature/Story/StoryView.swift
+++ b/Kartrider/Feature/Story/StoryView.swift
@@ -29,7 +29,6 @@ struct StoryView: View {
         ) {
             VStack(spacing: 16) {
                 Divider()
-                //                Group {
                 if storyViewModel.isLoading {
                     DescriptionBoxView(
                         text: storyViewModel.currentNode?.text ?? "")

--- a/Kartrider/Feature/Story/StoryView.swift
+++ b/Kartrider/Feature/Story/StoryView.swift
@@ -8,21 +8,20 @@ import SwiftUI
 
 struct StoryView: View {
     @Environment(\.modelContext) private var context
-    
+
     @EnvironmentObject private var coordinator: NavigationCoordinator
-    // TODO: iosConnectManager 단일 객체로 관리하기
-    @EnvironmentObject private var iosConnectManager: IosConnectManager
     @StateObject private var storyViewModel: StoryViewModel
-    
+
     init(content: ContentMeta) {
         _storyViewModel = StateObject(
             wrappedValue: StoryViewModel(content: content)
         )
     }
-    
+
     var body: some View {
         NavigationBarWrapper(
-            navStyle: NavigationBarStyle.play(title: storyViewModel.content.title),
+            navStyle: NavigationBarStyle.play(
+                title: storyViewModel.content.title),
             onTapLeft: {
                 storyViewModel.ttsManager.pause()
                 coordinator.pop()
@@ -30,76 +29,50 @@ struct StoryView: View {
         ) {
             VStack(spacing: 16) {
                 Divider()
-                Group {
-                    if storyViewModel.isLoading {
-                        DescriptionBoxView(text: storyViewModel.currentNode?.text ?? "")
+                //                Group {
+                if storyViewModel.isLoading {
+                    DescriptionBoxView(
+                        text: storyViewModel.currentNode?.text ?? "")
+                    Spacer()
+                } else if let errorMessage = storyViewModel.errorMessage {
+                    Text(errorMessage)
+                } else if let storyNode = storyViewModel.currentNode {
+                    VStack {
+
+                        DescriptionBoxView(text: storyNode.text)
+
+                        StoryNodeContentView(
+                            storyNode: storyNode,
+                            isDisabled: storyViewModel.isSequenceInProgress,
+                            selectChoice: storyViewModel.selectChoice(
+                                toId:),
+                            title: storyViewModel.content.title
+                        )
+
                         Spacer()
-                    } else if let errorMessage = storyViewModel.errorMessage {
-                        Text(errorMessage)
-                    } else if let storyNode = storyViewModel.currentNode {
-                        VStack {
-                            
-                            DescriptionBoxView(text: storyNode.text)
-                            
-                            StoryNodeContentView(
-                                storyNode: storyNode,
-                                isDisabled: storyViewModel.isSequenceInProgress,
-                                selectChoice: storyViewModel.selectChoice(toId:),
-                                title: storyViewModel.content.title
-                            )
-                            
-                            Spacer()
-                            
-                            TTSControlButton(isSpeaking: storyViewModel.isSpeaking) {
-                                storyViewModel.toggleSpeaking()
-                            }
-                            // TODO: ViewModel로 분리
-                            .disabled(
-                                storyViewModel.isTransitioningTTS
-                                || storyViewModel.isTogglingTTS)
+
+                        TTSControlButton(
+                            isSpeaking: storyViewModel.isTTSPlaying
+                        ) {
+                            storyViewModel.toggleSpeaking()
                         }
-                        .contentShape(Rectangle())
+                        // TODO: ViewModel로 분리
+                        .disabled(
+                            storyViewModel.isTransitioningTTS
+                                || storyViewModel.isTogglingTTS)
                     }
+                    .contentShape(Rectangle())
                 }
+
             }
-            
-            
         }
         .task {
             await storyViewModel.loadInitialNode(context: context)
         }
-        .onAppear {
-            // TODO: setConnectManager와 같은 메서드를 ViewModel에 만든 후, 호출
-            storyViewModel.iosConnectManager = iosConnectManager
-            storyViewModel.isSpeaking = iosConnectManager.isPlayTTS
-        }
-        // TODO: 곧 망함. or Combine을 활용해보자!
-        .onChange(of: iosConnectManager.selectedOption) { newOption in
-            guard let selected = newOption else { return }
-            
-            print("[DEBUG] 워치 선택 감지: \(selected.rawValue)")
-            storyViewModel.handleWatchChoice(option: selected)
-            
-            iosConnectManager.selectedOption = nil
-            
-        }
-        // TODO: 곧 망함. or Combine을 활용해보자!
-        .onChange(of: iosConnectManager.isPlayTTS) { newValue in
-            if newValue == storyViewModel.isSpeaking {
-                return
-            }
-            
-            if newValue {
-                storyViewModel.ttsManager.resume()
-            } else {
-                storyViewModel.ttsManager.pause()
-            }
-            storyViewModel.isSpeaking = newValue
-        }
         .onChange(of: storyViewModel.currentNode) { _, newNode in
             guard let storyNode = newNode else { return }
             guard !storyViewModel.isSequenceInProgress else { return }
-            
+
             Task {
                 await MainActor.run {
                     storyViewModel.isSequenceInProgress = true
@@ -109,11 +82,8 @@ struct StoryView: View {
                     storyNode, context: context)
             }
         }
-        .onChange(of: iosConnectManager.timeout) { newValue in
-            storyViewModel.handleTimeout(newValue)
-        }
     }
-    
+
     #Preview {
         let contentSample = ContentMeta(
             title: "title sample",

--- a/Kartrider/Feature/Tournament/TournamentViewModel.swift
+++ b/Kartrider/Feature/Tournament/TournamentViewModel.swift
@@ -5,48 +5,88 @@
 //  Created by J on 6/2/25.
 //
 
+import Combine
 import Foundation
 import SwiftData
 
 class TournamentViewModel: ObservableObject {
-    
+
+    let connectManager = IosConnectManager.shared
+
+    private var cancellable = Set<AnyCancellable>()
+
     @Published var currentCandidates: (Candidate, Candidate)?
     @Published var isFinished = false
     @Published var winner: Candidate?
     @Published var matchHistory: [TournamentStepData] = []
-    
+
     private let contentRepository: ContentRepositoryProtocol
     private let historyRepository: PlayHistoryRepositoryProtocol
     private let tournamentId: UUID
     private var tournament: Tournament?
     private var nextRoundCandidates: [Candidate] = []
     private var rounds: [[Candidate]] = []
-    private var currentRoundIndex = 0 // 지금 몇 라운드인지 ex. 8강, 4강, 결승
-    private var currentMatchIndex = 0 // 지금 라운드에서 몇번째 매치인지
-    
+    private var currentRoundIndex = 0  // 지금 몇 라운드인지 ex. 8강, 4강, 결승
+    private var currentMatchIndex = 0  // 지금 라운드에서 몇번째 매치인지
+
     var currentRoundDescription: String {
         guard rounds.indices.contains(currentRoundIndex) else { return "" }
         let count = rounds[currentRoundIndex].count
-        let roundText : String = (count == 2) ? "결승" : "\(count)강"
+        let roundText: String = (count == 2) ? "결승" : "\(count)강"
         let matchNumber = currentMatchIndex + 1
         let totalMatches = count / 2
         return "\(roundText)\n\(totalMatches)개의 경기 중 \(matchNumber)번째 경기"
     }
-    
+
+    @Published var selectedOption: StoryChoiceOption? = nil
+    @Published var decisionIndex = 0
+    @Published var decisionTask: Task<Void, Never>? = nil
+
+    var ttsManager = TTSManager()
+
     init(
         content: ContentMeta,
         contentRepository: ContentRepositoryProtocol = ContentRepository(),
-        historyRepository: PlayHistoryRepositoryProtocol = PlayHistoryRepository()
+        historyRepository: PlayHistoryRepositoryProtocol =
+            PlayHistoryRepository()
     ) {
         self.tournament = content.tournament
         self.tournamentId = content.tournament!.id
         self.contentRepository = contentRepository
         self.historyRepository = historyRepository
+
+        connectManager.$selectedOption
+            .receive(on: DispatchQueue.main)
+            .sink { newValue in
+                guard let option = newValue,
+                    let (a, b) = self.currentCandidates,
+                    self.selectedOption == nil
+                else { return }
+
+                self.decisionTask?.cancel()
+                self.decisionTask = nil
+
+                self.selectedOption = option
+                let selected = option == .a ? a : b
+                self.handleSelection(selected)
+            }
+            .store(in: &cancellable)
+
+        connectManager.$isTimeout
+            .receive(on: DispatchQueue.main)
+            .sink { newValue in
+                self.handleTimeout(newValue)
+            }
+            .store(in: &cancellable)
+
     }
-    
+
     func loadTournament(context: ModelContext) {
         do {
-            guard let tournament = try contentRepository.fetchTournament(by: tournamentId, context: context) else {
+            guard
+                let tournament = try contentRepository.fetchTournament(
+                    by: tournamentId, context: context)
+            else {
                 print("[ERROR] 토너먼트 찾을 수 없음")
                 return
             }
@@ -63,7 +103,7 @@ class TournamentViewModel: ObservableObject {
             print("[ERROR] 토너먼트 로딩 실패 : \(error)")
         }
     }
-    
+
     func prepareNextMatch() {
         let currentRound = rounds[currentRoundIndex]
         guard currentMatchIndex * 2 + 1 < currentRound.count else {
@@ -82,15 +122,15 @@ class TournamentViewModel: ObservableObject {
             }
             return
         }
-        
+
         let a = currentRound[currentMatchIndex * 2]
         let b = currentRound[currentMatchIndex * 2 + 1]
         currentCandidates = (a, b)
     }
-    
+
     func select(_ selected: Candidate) {
         guard let (a, b) = currentCandidates else { return }
-        
+
         // 기록 저장
         let step = TournamentStepData(
             round: rounds[currentRoundIndex].count,
@@ -101,17 +141,16 @@ class TournamentViewModel: ObservableObject {
             timestamp: Date()
         )
         matchHistory.append(step)
-        
+
         nextRoundCandidates.append(selected)
         currentMatchIndex += 1
         prepareNextMatch()
     }
 
-    
     private func makeNextRound(from round: [Candidate]) -> [Candidate] {
         return round
     }
-    
+
     func finishTournamentAndSave(context: ModelContext) {
         guard let winner = winner else { return }
         do {
@@ -125,4 +164,85 @@ class TournamentViewModel: ObservableObject {
             print("[ERROR] 토너먼트 히스토리 저장 실패 : \(error)")
         }
     }
+
+    func handleSelection(_ candidate: Candidate) {
+
+        Task {
+            // TODO: ttsManager.stop : Async함수 아님
+            await ttsManager.stop()
+            connectManager.sendChoiceInterrupt()
+            await speakSelectedChoice(candidate)
+            try? await Task.sleep(nanoseconds: 200_000_000)
+
+            select(candidate)
+            decisionIndex += 1
+            speakCurrentMatch()
+        }
+    }
+    func speakCurrentMatch() {
+        guard let (a, b) = currentCandidates else { return }
+
+        decisionTask?.cancel()
+
+        connectManager.isTimeout = false
+        connectManager.isFirstRequest = true
+
+        decisionTask = Task {
+            connectManager.sendStageDecisionWithFirstTTS(
+                decisionIndex)
+            await ttsManager.speakSequentially(currentRoundDescription)
+            await ttsManager.speakSequentially("A. \(a.name)")
+            await ttsManager.speakSequentially("B. \(b.name)")
+            connectManager.sendStageDecisionWithFirstTimer(
+                decisionIndex)
+        }
+    }
+
+    func playSecondTTS() {
+        guard let (a, b) = currentCandidates else { return }
+        decisionTask?.cancel()
+
+        let texts = [
+            "선택지가 다시 한번 재생됩니다",
+            "A. \(a.name)",
+            "B. \(b.name)",
+        ]
+
+        decisionTask = Task {
+            connectManager.sendStageDecisionWithSecTTS(decisionIndex)
+            for text in texts { await ttsManager.speakSequentially(text) }
+            connectManager.sendStageDecisionWithSecTimer(decisionIndex)
+        }
+    }
+
+    func speakOnlyChoices() {
+        guard let (a, b) = currentCandidates else { return }
+        Task {
+            await ttsManager.speakSequentially("A. \(a.name)")
+            await ttsManager.speakSequentially("B. \(b.name)")
+        }
+    }
+
+    func speakSelectedChoice(_ candidate: Candidate) async {
+        await ttsManager.speakSequentially("\(candidate.name) 선택")
+    }
+
+    func handleTimeout(_ newValue: Bool?) {
+        let isTimeout = newValue == true
+        let sameIndex = connectManager.decisionIndex == decisionIndex
+        let noSelection = selectedOption == nil
+
+        guard isTimeout, sameIndex, noSelection else { return }
+
+        if connectManager.isFirstRequest {
+            playSecondTTS()
+        } else {
+            if let (aCandidate, _) = currentCandidates {
+                selectedOption = .a
+                handleSelection(aCandidate)
+            }
+        }
+        connectManager.isTimeout = false
+    }
+
 }

--- a/Kartrider/Navigation/AppNavigationView.swift
+++ b/Kartrider/Navigation/AppNavigationView.swift
@@ -12,7 +12,6 @@ struct AppNavigationView: View {
 
     @StateObject var coordinator = NavigationCoordinator()
     @StateObject private var ttsManager = TTSManager()
-    @EnvironmentObject private var iosConnectManager: IosConnectManager
 
     var body: some View {
         NavigationStack(path: $coordinator.path) {

--- a/Pickacha Watch App/WatchFeature/Story/Decision/DecisionViewModel.swift
+++ b/Pickacha Watch App/WatchFeature/Story/Decision/DecisionViewModel.swift
@@ -38,7 +38,7 @@ class DecisionViewModel: ObservableObject {
                 newValue in
                 if newValue {
                     self.resetState()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                         self.isTimerRunning = true  // 타이머 화면이 2번 그려지는데(0.0001초 동안 타이머->선택지재생->타이머) 약간의 로직 수정이 필요합니다
                         self.makeChoice()
                     }
@@ -52,7 +52,7 @@ class DecisionViewModel: ObservableObject {
         connectManager.$isInterrupted
             .receive(on: DispatchQueue.main)
             .sink { newValue in
-                if newValue {
+                if newValue == true {
                     self.interruptByPhone()
                 }
             }
@@ -135,6 +135,8 @@ class DecisionViewModel: ObservableObject {
             print("unavailable")
             return
         }
+
+        if motionManager.isDeviceMotionActive { return }
 
         motionManager.deviceMotionUpdateInterval = 0.1
         isSetMiddle = false


### PR DESCRIPTION
## #️⃣ 관련 이슈
> ex) closes #80 

---

## 💻 작업 내용

- IosConnectManager와 각 View/ViewModel을 수정하여 싱글톤 패턴을 적용시킴
- 변수 이름을 좀 더 직관적으로 수정

---

## 📝 코드 설명

1. IosConnectManager와 각 View/ViewModel을 수정하여 싱글톤 패턴을 적용하고 connectManager에서 값을 받아 UI가 바뀌는 onchange는 combine으로 값이 변할때 동작하도록 수정하였습니다
워치커넥트매니저에서 한번 적은 내용입니다만 싱글톤 패턴이 무엇이냐.. 인스턴스를 전역에 하나만 생성해서 공용으로 사용하고 싶을 때 쓰는 패턴입니다. 여기서 WatchConnectivity는 한 번 세션을 열면 그 세션을 통해 메시지를 주고받는데, 워치와 아이폰 간 연결 상태를 앱 전체에서 공유해야 해서 싱글톤 패턴을 사용했습니다.
```Swift
static let shared = IosConnectManager(), private init 이 부분이 싱글톤 패턴 적용하는 부분의 핵심이구요
class IosConnectManager: NSObject, WCSessionDelegate, ObservableObject {

    static let shared = IosConnectManager()

    var session: WCSession

    private init(session: WCSession = .default) {
        self.session = session
        super.init()
        if WCSession.isSupported() {
            self.session.delegate = self
            self.session.activate()
        } else {
            print("[ERROR] WCSession not supported")
        }
    }
```
onChange 중에서 커넥트매니저에서 관련 부분을 viewmodel로 넘기고 Combine을 사용하는 방식으로 수정했습니다
왜 컴바인을 썼냐? IosConnectManager.shared.hasStartedContent 값이 변하면 WatchStartViewModel.hasStartedContent 값도 자동으로 바뀌도록 연결하고 싶어서. 근데 onChange 파티는 싫기도 했고 싱글톤을 쓰니까 자연스럽게 combine을 써야하는 상황이 왔답니다..22
워치쪽과 다른점이라고 한다면
```swift
 @StateObject private var storyViewModel: StoryViewModel

    init(content: ContentMeta) {
        _storyViewModel = StateObject(
            wrappedValue: StoryViewModel(content: content)
        )
    }
``` 
이렇게 viewmodel을 생성할 때 넘겨줄 값이 있다는 점이겠군요

그래서 watch-ios 간의 연결은 문제가 없는 상황입니다. 그래서 이전에 하드코딩했던 부분도 connectManager를 통해 해결하고 없앴어요~!

---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 


