### PR TITLE
#88 - Stage enum으로 바꾸기

### DIFF
--- a/Pickacha Watch App/Stage.swift
+++ b/Pickacha Watch App/Stage.swift
@@ -1,0 +1,15 @@
+//
+//  Stage.swift
+//  Pickacha Watch App
+//
+//  Created by jiwon on 7/5/25.
+//
+
+import Foundation
+
+enum Stage: String {
+    case idle
+    case exposition
+    case decision
+    case ending
+}

--- a/Pickacha Watch App/WatchConnectManager.swift
+++ b/Pickacha Watch App/WatchConnectManager.swift
@@ -104,19 +104,19 @@ class WatchConnectManager: NSObject, WCSessionDelegate, ObservableObject {
             print("[DEBUG] stage did change to '\(self.currentStage)'")
 
             switch currentStage {
-            case "idle":
+            case Stage.idle.rawValue:
                 print("[IDLE] startContent: \(self.hasStartedContent)")
                 self.message = [
                     "currentStage": "idle",
                     "hasStartedContent": self.hasStartedContent,
                 ]
-            case "exposition":
+            case Stage.exposition.rawValue:
                 print("[EXPOSITION] isPlayTTS: \(self.isTTSPlaying)")
                 self.message = [
                     "currentStage": "exposition",
                     "isTTSPlaying": self.isTTSPlaying,
                 ]
-            case "decision":
+            case Stage.decision.rawValue:
                 print(
                     "[DECISION] isTimerRunning: \(self.isTimerRunning), decisionIndex: \(self.decisionIndex), isFirstRequest: \(self.isFirstRequest)"
                 )
@@ -126,7 +126,7 @@ class WatchConnectManager: NSObject, WCSessionDelegate, ObservableObject {
                     "decisionIndex": self.decisionIndex,
                     "isFirstRequest": self.isFirstRequest,
                 ]
-            case "ending":
+            case Stage.ending.rawValue:
                 print("[ENDING] isTimerRunning: \(self.isTimerRunning)")
                 self.message = [
                     "currentStage": "ending",

--- a/Pickacha Watch App/WatchFeature/Outro/WatchOutroViewModel.swift
+++ b/Pickacha Watch App/WatchFeature/Outro/WatchOutroViewModel.swift
@@ -23,7 +23,12 @@ class WatchOutroViewModel: ObservableObject {
     init() {
         connectManager.$isTimerRunning
             .receive(on: DispatchQueue.main)
-            .assign(to: \.isTimerRunning, on: self)
+            .sink { newValue in
+                if newValue {
+                    self.startTimer()
+                }
+                self.isTimerRunning = newValue
+            }
             .store(in: &cancellable)
     }
 

--- a/Pickacha Watch App/WatchFeature/Story/Decision/DecisionViewModel.swift
+++ b/Pickacha Watch App/WatchFeature/Story/Decision/DecisionViewModel.swift
@@ -36,16 +36,21 @@ class DecisionViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink {
                 newValue in
-                if newValue {
-                    self.resetState()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        self.isTimerRunning = true  // 타이머 화면이 2번 그려지는데(0.0001초 동안 타이머->선택지재생->타이머) 약간의 로직 수정이 필요합니다
-                        self.makeChoice()
+                if self.connectManager.currentStage == Stage.decision.rawValue {
+                    if newValue {
+                        self.resetState()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            self.isTimerRunning = true  // 타이머 화면이 2번 그려지는데(0.0001초 동안 타이머->선택지재생->타이머) 약간의 로직 수정이 필요합니다
+                            self.makeChoice()
+                        }
+                    } else {
+                        self.isTimerRunning = false
                     }
+                    print("[DECISION] isTimerRunning: \(self.isTimerRunning)")
                 } else {
+
                     self.isTimerRunning = false
                 }
-                print("[DECISION] isTimerRunning: \(self.isTimerRunning)")
             }
             .store(in: &cancellable)
 

--- a/Pickacha Watch App/WatchFeature/Story/WatchStoryView.swift
+++ b/Pickacha Watch App/WatchFeature/Story/WatchStoryView.swift
@@ -12,15 +12,14 @@ struct WatchStoryView: View {
     @EnvironmentObject private var coordinator: WatchNavigationCoordinator
     @StateObject private var watchStoryViewModel = WatchStoryViewModel()
 
-    // TODO: 컴포넌트로 분리 - 로직 수정 -> Gigi: 컴포넌트.. 어떤 거를 만들어야 하나요..?
     var body: some View {
         VStack {
             switch watchStoryViewModel.currentStage {
-            case "exposition":
+            case Stage.exposition.rawValue:
                 ExpositionView()
-            case "decision":
+            case Stage.decision.rawValue:
                 DecisionView()
-            case "ending":
+            case Stage.ending.rawValue:
                 Color.clear.onAppear {
                     coordinator.push(.outro)
                 }

--- a/Pickacha Watch App/WatchFeature/Story/WatchStoryViewModel.swift
+++ b/Pickacha Watch App/WatchFeature/Story/WatchStoryViewModel.swift
@@ -11,11 +11,10 @@ import Foundation
 class WatchStoryViewModel: ObservableObject {
 
     let connectManager = WatchConnectManager.shared
-    // MARK: 시간되면 ENUM 타입으로 변경 -> Gigi: enum type으로 변경하니까 값이 잘 전달이 안돼서 일단 string으로 두었습니다
 
     private var cancellable = Set<AnyCancellable>()
 
-    @Published var currentStage: String = "idle"
+    @Published var currentStage: String = Stage.idle.rawValue
 
     init() {
         connectManager.$currentStage


### PR DESCRIPTION
## #️⃣ 관련 이슈
> ex) closes #88 

---

## 💻 작업 내용

 Stage enum으로 바꾸기

---

## 📝 코드 설명

```swift
enum Stage: String {
    case idle
    case exposition
    case decision
    case ending
}
``` 

- 원래 "idle", "exposition" 이런 식으로 string으로 되어있었는데 Stage.idle.rawValue 이런식으로 가져다 쓰게 수정했어요

---

## 📁 참고한 내용 (선택)
* (주소 첨부)
* 
---

## ✋🏻 잠깐! 확인하셨나요?
- [ ] 컨벤션 확인
- [ ] 기능 정상 작동 테스트 완료
- [ ] 디버깅 코드 및 주석 제거
- [ ] 사용하지 않는 코드/파일 정리
- [ ] 작업 내용 및 코드 설명 작성 


