### PR TITLE
🐛 Bug: TTS 메모시 해제 문제 해결

### DIFF
--- a/Kartrider/Sources/Feature/Story/StoryView.swift
+++ b/Kartrider/Sources/Feature/Story/StoryView.swift
@@ -23,7 +23,7 @@ struct StoryView: View {
             navStyle: NavigationBarStyle.play(
                 title: storyViewModel.content.title),
             onTapLeft: {
-                storyViewModel.ttsManager.pause()
+                storyViewModel.cleanup()
                 coordinator.pop()
             }
         ) {

--- a/Kartrider/Sources/Feature/Story/StoryViewModel.swift
+++ b/Kartrider/Sources/Feature/Story/StoryViewModel.swift
@@ -85,11 +85,20 @@ class StoryViewModel: ObservableObject {
 
     deinit {
         decisionTask?.cancel()
-        ttsManager.stop()
         cancellable.removeAll()
+        let tts = ttsManager
+        DispatchQueue.main.async {
+            tts.stop()
+        }
         Log.info("StoryViewModel deinit")
     }
 
+    func cleanup() {
+        decisionTask?.cancel()
+        decisionTask = nil
+        ttsManager.stop()
+    }
+    
     @MainActor
     func loadInitialNode(context: ModelContext) async {
         isLoading = true

--- a/Kartrider/Sources/Feature/Story/StoryViewModel.swift
+++ b/Kartrider/Sources/Feature/Story/StoryViewModel.swift
@@ -52,10 +52,9 @@ class StoryViewModel: ObservableObject {
 
         connectManager.$isTTSPlaying
             .receive(on: DispatchQueue.main)
-            .sink { newValue in
-                if newValue == self.isTTSPlaying {
-                    return
-                }
+            .sink { [weak self] newValue in
+                guard let self else { return }
+                if newValue == self.isTTSPlaying { return }
 
                 if newValue {
                     self.ttsManager.resume()
@@ -68,9 +67,9 @@ class StoryViewModel: ObservableObject {
 
         connectManager.$selectedOption
             .receive(on: DispatchQueue.main)
-            .sink { newValue in
-                guard let selected = newValue else { return }
-                print("[DEBUG] 워치 선택 감지: \(selected.rawValue)")
+            .sink { [weak self] newValue in
+                guard let self, let selected = newValue else { return }
+                Log.debug("워치 선택 감지: \(selected.rawValue)")
                 self.handleWatchChoice(option: selected)
                 self.connectManager.selectedOption = nil
             }
@@ -78,8 +77,8 @@ class StoryViewModel: ObservableObject {
 
         connectManager.$isTimeout
             .receive(on: DispatchQueue.main)
-            .sink { newValue in
-                self.handleTimeout(newValue)
+            .sink { [weak self] newValue in
+                self?.handleTimeout(newValue)
             }
             .store(in: &cancellable)
     }

--- a/Kartrider/Sources/Feature/Story/StoryViewModel.swift
+++ b/Kartrider/Sources/Feature/Story/StoryViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+
 //
 //  StoryViewModel.swift
 //  Kartrider
@@ -9,7 +10,6 @@ import Foundation
 import SwiftData
 
 class StoryViewModel: ObservableObject {
-
     let connectManager = IosConnectManager.shared
 
     private var cancellable = Set<AnyCancellable>()
@@ -31,7 +31,7 @@ class StoryViewModel: ObservableObject {
 
     @Published var decisionIndex = 0
     private var secPlayed = false
-    private var decisionTask: Task<Void, Never>? = nil
+    private var decisionTask: Task<Void, Never>?
 
     var ttsManager = TTSManager()
 
@@ -39,9 +39,9 @@ class StoryViewModel: ObservableObject {
         repository: ContentRepositoryProtocol = ContentRepository(),
         content: ContentMeta
     ) {
-        self.contentRepository = repository
+        contentRepository = repository
         self.content = content
-        self.startNodeId = content.story?.startNodeId ?? ""
+        startNodeId = content.story?.startNodeId ?? ""
 
         ttsManager.didSpeakingStateChanged = { [weak self] speaking in
             DispatchQueue.main.async {
@@ -54,14 +54,14 @@ class StoryViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newValue in
                 guard let self else { return }
-                if newValue == self.isTTSPlaying { return }
+                if newValue == isTTSPlaying { return }
 
                 if newValue {
-                    self.ttsManager.resume()
+                    ttsManager.resume()
                 } else {
-                    self.ttsManager.pause()
+                    ttsManager.pause()
                 }
-                self.isTTSPlaying = newValue
+                isTTSPlaying = newValue
             }
             .store(in: &cancellable)
 
@@ -70,8 +70,8 @@ class StoryViewModel: ObservableObject {
             .sink { [weak self] newValue in
                 guard let self, let selected = newValue else { return }
                 Log.debug("워치 선택 감지: \(selected.rawValue)")
-                self.handleWatchChoice(option: selected)
-                self.connectManager.selectedOption = nil
+                handleWatchChoice(option: selected)
+                connectManager.selectedOption = nil
             }
             .store(in: &cancellable)
 
@@ -97,8 +97,9 @@ class StoryViewModel: ObservableObject {
         do {
             if let storyId = content.story?.id,
                let story = try contentRepository.fetchStory(
-                by: storyId, context: context),
-                let node = story.nodes.first(where: { $0.id == startNodeId })
+                   by: storyId, context: context
+               ),
+               let node = story.nodes.first(where: { $0.id == startNodeId })
             {
                 currentNode = node
                 await handleStoryNode(node, context: context)
@@ -113,8 +114,8 @@ class StoryViewModel: ObservableObject {
 
     func goToNextNode(from currentNode: StoryNode) {
         guard let nextId = currentNode.nextId,
-            let story = currentNode.story,
-            let nextNode = story.nodes.first(where: { $0.id == nextId })
+              let story = currentNode.story,
+              let nextNode = story.nodes.first(where: { $0.id == nextId })
         else {
             errorMessage = "다음 스토리 노드를 찾을 수 없습니다"
             return
@@ -126,9 +127,9 @@ class StoryViewModel: ObservableObject {
     }
 
     func selectChoice(toId: String) {
-        guard let currentNode = currentNode,
-            let story = currentNode.story,
-            let nextNode = story.nodes.first(where: { $0.id == toId })
+        guard let currentNode,
+              let story = currentNode.story,
+              let nextNode = story.nodes.first(where: { $0.id == toId })
         else {
             errorMessage = "선택한 노드를 찾을 수 없습니다"
             return
@@ -142,13 +143,13 @@ class StoryViewModel: ObservableObject {
         Log.info("선택한 길: \(selectedPath)")
 
         self.currentNode = nextNode
-        self.decisionIndex += 1
+        decisionIndex += 1
     }
 
     @MainActor
     func handleStoryNode(_ node: StoryNode, context: ModelContext) async {
         //        await ttsManager.speakSequentially(node.text)
-        self.isSequenceInProgress = true
+        isSequenceInProgress = true
 
         if node.type == .decision {
             connectManager.isTimeout = false
@@ -163,9 +164,9 @@ class StoryViewModel: ObservableObject {
         } else if node.type == .exposition {
             connectManager.sendStageExpositionWithResume()
             await ttsManager.speakSequentially(node.text)
-            self.goToNextNode(from: node)
+            goToNextNode(from: node)
         }
-        self.isSequenceInProgress = false
+        isSequenceInProgress = false
     }
 
     private func checkEndingCondition() -> String {
@@ -186,7 +187,7 @@ class StoryViewModel: ObservableObject {
         do {
             if let storyId = content.story?.id,
                let story = try contentRepository.fetchStory(by: storyId, context: context),
-                let endingNode = story.nodes.first(where: { $0.id == toId })
+               let endingNode = story.nodes.first(where: { $0.id == toId })
             {
                 currentNode = endingNode
                 connectManager.sendStageEndingTTS()
@@ -221,8 +222,9 @@ class StoryViewModel: ObservableObject {
             self.isTogglingTTS = false
         }
     }
+
     func handleWatchChoice(option: StoryChoiceOption) {
-        guard let currentNode = currentNode else { return }
+        guard let currentNode else { return }
         connectManager.sendChoiceInterrupt()
 
         switch option {
@@ -230,6 +232,7 @@ class StoryViewModel: ObservableObject {
             if let toId = currentNode.choiceA?.toId {
                 selectChoice(toId: toId)
             }
+
         case .b:
             if let toId = currentNode.choiceB?.toId {
                 selectChoice(toId: toId)
@@ -266,7 +269,9 @@ class StoryViewModel: ObservableObject {
         decisionTask = Task {
             secPlayed = true
             connectManager.sendStageDecisionWithSecTTS(decisionIndex)
-            for text in texts { await ttsManager.speakSequentially(text) }
+            for text in texts {
+                await ttsManager.speakSequentially(text)
+            }
             connectManager.sendStageDecisionWithSecTimer(decisionIndex)
         }
     }
@@ -275,7 +280,7 @@ class StoryViewModel: ObservableObject {
         let isTimeout = newValue == true
         let noSelection = connectManager.selectedOption == nil
         guard isTimeout, noSelection,
-            let node = currentNode, node.type == .decision
+              let node = currentNode, node.type == .decision
         else { return }
 
         if connectManager.isFirstRequest == true {
@@ -288,5 +293,4 @@ class StoryViewModel: ObservableObject {
         }
         connectManager.isTimeout = false
     }
-
 }

--- a/Kartrider/Sources/Feature/Story/StoryViewModel.swift
+++ b/Kartrider/Sources/Feature/Story/StoryViewModel.swift
@@ -32,6 +32,7 @@ class StoryViewModel: ObservableObject {
     @Published var decisionIndex = 0
     private var secPlayed = false
     private var decisionTask: Task<Void, Never>?
+    private var nodeHandlingTask: Task<Void, Never>?
 
     var ttsManager = TTSManager()
 
@@ -85,20 +86,20 @@ class StoryViewModel: ObservableObject {
 
     deinit {
         decisionTask?.cancel()
+        nodeHandlingTask?.cancel()
         cancellable.removeAll()
-        let tts = ttsManager
-        DispatchQueue.main.async {
-            tts.stop()
-        }
+        ttsManager.stop()
         Log.info("StoryViewModel deinit")
     }
 
     func cleanup() {
         decisionTask?.cancel()
         decisionTask = nil
+        nodeHandlingTask?.cancel()
+        nodeHandlingTask = nil
         ttsManager.stop()
     }
-    
+
     @MainActor
     func loadInitialNode(context: ModelContext) async {
         isLoading = true
@@ -157,25 +158,36 @@ class StoryViewModel: ObservableObject {
 
     @MainActor
     func handleStoryNode(_ node: StoryNode, context: ModelContext) async {
-        //        await ttsManager.speakSequentially(node.text)
-        isSequenceInProgress = true
+        nodeHandlingTask?.cancel()
 
-        if node.type == .decision {
-            connectManager.isTimeout = false
-            connectManager.isFirstRequest = true
-            secPlayed = false
-            firstDecision(node: node)
+        nodeHandlingTask = Task { [weak self] in
+            guard let self else { return }
 
-        } else if node.nextId == nil {
-            endingId = checkEndingCondition()
-            await goToEndingNode(toId: endingId, context: context)
+            isSequenceInProgress = true
 
-        } else if node.type == .exposition {
-            connectManager.sendStageExpositionWithResume()
-            await ttsManager.speakSequentially(node.text)
-            goToNextNode(from: node)
+            if node.type == .decision {
+                guard !Task.isCancelled else { return }
+                connectManager.isTimeout = false
+                connectManager.isFirstRequest = true
+                secPlayed = false
+                firstDecision(node: node)
+
+            } else if node.nextId == nil {
+                guard !Task.isCancelled else { return }
+                endingId = checkEndingCondition()
+                await goToEndingNode(toId: endingId, context: context)
+
+            } else if node.type == .exposition {
+                guard !Task.isCancelled else { return }
+                connectManager.sendStageExpositionWithResume()
+                await ttsManager.speakSequentially(node.text)
+
+                guard !Task.isCancelled else { return }
+                goToNextNode(from: node)
+            }
+
+            isSequenceInProgress = false
         }
-        isSequenceInProgress = false
     }
 
     private func checkEndingCondition() -> String {
@@ -251,7 +263,9 @@ class StoryViewModel: ObservableObject {
 
     func firstDecision(node: StoryNode) {
         decisionTask?.cancel()
-        decisionTask = Task {
+        decisionTask = Task { [weak self] in
+            guard let self else { return }
+
             connectManager.sendStageDecisionWithFirstTTS(decisionIndex)
             if !node.text.isEmpty {
                 await ttsManager.speakSequentially(node.text)
@@ -275,7 +289,9 @@ class StoryViewModel: ObservableObject {
             "B. \(node.choiceB?.text ?? "")",
         ]
 
-        decisionTask = Task {
+        decisionTask = Task { [weak self] in
+            guard let self else { return }
+
             secPlayed = true
             connectManager.sendStageDecisionWithSecTTS(decisionIndex)
             for text in texts {

--- a/Kartrider/Sources/Feature/Story/StoryViewModel.swift
+++ b/Kartrider/Sources/Feature/Story/StoryViewModel.swift
@@ -83,6 +83,13 @@ class StoryViewModel: ObservableObject {
             .store(in: &cancellable)
     }
 
+    deinit {
+        decisionTask?.cancel()
+        ttsManager.stop()
+        cancellable.removeAll()
+        Log.info("StoryViewModel deinit")
+    }
+
     @MainActor
     func loadInitialNode(context: ModelContext) async {
         isLoading = true
@@ -132,7 +139,7 @@ class StoryViewModel: ObservableObject {
         } else if let choice = currentNode.choiceB, choice.toId == toId {
             selectedPath.append(.b)
         }
-        print("[INFO] 선택한 길: \(selectedPath)")
+        Log.info("선택한 길: \(selectedPath)")
 
         self.currentNode = nextNode
         self.decisionIndex += 1
@@ -166,7 +173,7 @@ class StoryViewModel: ObservableObject {
 
         for condition in story.endingConditions {
             if condition.path == selectedPath {
-                print("[INFO] 일치하는 엔딩 도달: \(condition.toId)")
+                Log.info("일치하는 엔딩 도달: \(condition.toId)")
                 return condition.toId
             }
         }
@@ -198,7 +205,7 @@ class StoryViewModel: ObservableObject {
 
     func toggleSpeaking() {
         if isTogglingTTS {
-            print("[INFO] 잠시 토글 비활성화중")
+            Log.debug("잠시 토글 비활성화중")
             return
         }
         isTogglingTTS = true

--- a/Kartrider/Sources/Feature/Tournament/TournamentView.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentView.swift
@@ -23,6 +23,7 @@ struct TournamentView: View {
         NavigationBarWrapper(
             navStyle: .play(title: tournamentViewModel.title),
             onTapLeft: {
+                tournamentViewModel.cleanup()
                 coordinator.pop()
             }
         ) {

--- a/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
@@ -97,11 +97,20 @@ class TournamentViewModel: ObservableObject {
 
     deinit {
         decisionTask?.cancel()
-        ttsManager.stop()
         cancellable.removeAll()
+        let tts = ttsManager
+        DispatchQueue.main.async {
+            tts.stop()
+        }
         Log.info("TournamentViewModel deinit")
     }
 
+    func cleanup() {
+        decisionTask?.cancel()
+        decisionTask = nil
+        ttsManager.stop()
+    }
+    
     func setContext(_ context: ModelContext) {
         self.context = context
     }

--- a/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
@@ -10,7 +10,6 @@ import Foundation
 import SwiftData
 
 class TournamentViewModel: ObservableObject {
-
     let connectManager = IosConnectManager.shared
 
     private var cancellable = Set<AnyCancellable>()
@@ -26,7 +25,7 @@ class TournamentViewModel: ObservableObject {
             connectManager.isFirstRequest = true
         }
     }
-    
+
     @Published var isFinished = false
     @Published var winner: Candidate?
 
@@ -36,8 +35,8 @@ class TournamentViewModel: ObservableObject {
     private var tournament: Tournament?
     private var nextRoundCandidates: [Candidate] = []
     private var rounds: [[Candidate]] = []
-    private var currentRoundIndex = 0  // 지금 몇 라운드인지 ex. 8강, 4강, 결승
-    private var currentMatchIndex = 0  // 지금 라운드에서 몇번째 매치인지
+    private var currentRoundIndex = 0 // 지금 몇 라운드인지 ex. 8강, 4강, 결승
+    private var currentMatchIndex = 0 // 지금 라운드에서 몇번째 매치인지
 
     var currentRoundDescription: String {
         guard rounds.indices.contains(currentRoundIndex) else { return "" }
@@ -47,7 +46,7 @@ class TournamentViewModel: ObservableObject {
         let totalMatches = count / 2
         return "\(roundText)\n\(totalMatches)개의 경기 중 \(matchNumber)번째 경기"
     }
-    
+
     @Published var selectedOption: StoryChoiceOption? = nil
     @Published var decisionIndex = 0
     @Published var decisionTask: Task<Void, Never>? = nil
@@ -65,26 +64,26 @@ class TournamentViewModel: ObservableObject {
             fatalError("[FATAL] TournamentViewModel 초기화 실패 — content.tournament가 nil")
         }
         self.tournament = tournament
-        self.tournamentId = tournament.id
+        tournamentId = tournament.id
         self.contentRepository = contentRepository
         self.historyRepository = historyRepository
-        self.title = content.title
+        title = content.title
 
         connectManager.$selectedOption
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newValue in
                 guard let self,
                       let option = newValue,
-                      let (a, b) = self.currentCandidates,
-                      self.selectedOption == nil
+                      let (a, b) = currentCandidates,
+                      selectedOption == nil
                 else { return }
 
-                self.decisionTask?.cancel()
-                self.decisionTask = nil
+                decisionTask?.cancel()
+                decisionTask = nil
 
-                self.selectedOption = option
+                selectedOption = option
                 let selected = option == .a ? a : b
-                self.handleSelection(selected)
+                handleSelection(selected)
             }
             .store(in: &cancellable)
 
@@ -112,7 +111,8 @@ class TournamentViewModel: ObservableObject {
         do {
             guard
                 let tournament = try contentRepository.fetchTournament(
-                    by: tournamentId, context: context)
+                    by: tournamentId, context: context
+                )
             else {
                 Log.error("토너먼트 찾을 수 없음")
                 return
@@ -157,7 +157,7 @@ class TournamentViewModel: ObservableObject {
         let b = currentRound[currentMatchIndex * 2 + 1]
         currentCandidates = (a, b)
     }
-    
+
     @MainActor
     func select(_ selected: Candidate) {
         guard let (a, b) = currentCandidates else { return }
@@ -178,11 +178,11 @@ class TournamentViewModel: ObservableObject {
     }
 
     private func makeNextRound(from round: [Candidate]) -> [Candidate] {
-        return round
+        round
     }
 
     func finishTournamentAndSave(context: ModelContext) {
-        guard let winner = winner, let tournament = tournament else { return }
+        guard let winner, let tournament else { return }
         do {
             try historyRepository.saveTournamentHistory(
                 context: context,
@@ -211,7 +211,7 @@ class TournamentViewModel: ObservableObject {
             await speakCurrentMatch()
         }
     }
-    
+
     @MainActor
     func speakCurrentMatch() {
         guard let (a, b) = currentCandidates else { return }
@@ -234,7 +234,7 @@ class TournamentViewModel: ObservableObject {
         }
     }
 
-    func playSecondTTS() { 
+    func playSecondTTS() {
         guard let (a, b) = currentCandidates else { return }
         decisionTask?.cancel()
 
@@ -247,7 +247,9 @@ class TournamentViewModel: ObservableObject {
         decisionTask = Task {
             connectManager.sendStageDecisionWithSecTTS(decisionIndex)
             await MainActor.run { self.isTTSPlaying = true }
-            for text in texts { await ttsManager.speakSequentially(text) }
+            for text in texts {
+                await ttsManager.speakSequentially(text)
+            }
             await MainActor.run { self.isTTSPlaying = false }
             connectManager.sendStageDecisionWithSecTimer(decisionIndex)
         }
@@ -278,9 +280,9 @@ class TournamentViewModel: ObservableObject {
     @MainActor
     func handleTournamentEndingTTS() async {
         connectManager.sendStageEndingTTS()
-        
-        guard let winner = self.winner else { return }
-        
+
+        guard let winner else { return }
+
         isTTSPlaying = true
         ttsManager.stop()
         try? await Task.sleep(nanoseconds: 300_000_000)

--- a/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
@@ -96,6 +96,13 @@ class TournamentViewModel: ObservableObject {
             .store(in: &cancellable)
     }
 
+    deinit {
+        decisionTask?.cancel()
+        ttsManager.stop()
+        cancellable.removeAll()
+        Log.info("TournamentViewModel deinit")
+    }
+
     func setContext(_ context: ModelContext) {
         self.context = context
     }
@@ -107,7 +114,7 @@ class TournamentViewModel: ObservableObject {
                 let tournament = try contentRepository.fetchTournament(
                     by: tournamentId, context: context)
             else {
-                print("[ERROR] 토너먼트 찾을 수 없음")
+                Log.error("토너먼트 찾을 수 없음")
                 return
             }
             self.tournament = tournament
@@ -120,7 +127,7 @@ class TournamentViewModel: ObservableObject {
             matchHistory = []
             prepareNextMatch()
         } catch {
-            print("[ERROR] 토너먼트 로딩 실패 : \(error)")
+            Log.error("토너먼트 로딩 실패: \(error)")
         }
     }
 
@@ -183,8 +190,9 @@ class TournamentViewModel: ObservableObject {
                 winner: winner,
                 matchHistory: matchHistory
             )
+            Log.info("토너먼트 히스토리 저장 완료")
         } catch {
-            print("[ERROR] 토너먼트 히스토리 저장 실패 : \(error)")
+            Log.error("토너먼트 히스토리 저장 실패: \(error)")
         }
     }
 

--- a/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
@@ -37,6 +37,7 @@ class TournamentViewModel: ObservableObject {
     private var rounds: [[Candidate]] = []
     private var currentRoundIndex = 0 // 지금 몇 라운드인지 ex. 8강, 4강, 결승
     private var currentMatchIndex = 0 // 지금 라운드에서 몇번째 매치인지
+    private var selectionTask: Task<Void, Never>?
 
     var currentRoundDescription: String {
         guard rounds.indices.contains(currentRoundIndex) else { return "" }
@@ -97,17 +98,17 @@ class TournamentViewModel: ObservableObject {
 
     deinit {
         decisionTask?.cancel()
+        selectionTask?.cancel()
         cancellable.removeAll()
-        let tts = ttsManager
-        DispatchQueue.main.async {
-            tts.stop()
-        }
+        ttsManager.stop()
         Log.info("TournamentViewModel deinit")
     }
 
     func cleanup() {
         decisionTask?.cancel()
         decisionTask = nil
+        selectionTask?.cancel()
+        selectionTask = nil
         ttsManager.stop()
     }
     
@@ -206,17 +207,30 @@ class TournamentViewModel: ObservableObject {
     }
 
     func handleSelection(_ candidate: Candidate) {
-        Task {
-            // TODO: ttsManager.stop : Async함수 아님
+        selectionTask?.cancel()
+
+        selectionTask = Task { [weak self] in
+            guard let self else { return }
+
+            guard !Task.isCancelled else { return }
+
             ttsManager.stop()
             connectManager.sendChoiceInterrupt()
+
+            guard !Task.isCancelled else { return }
             await speakSelectedChoice(candidate)
+
+            guard !Task.isCancelled else { return }
             try? await Task.sleep(nanoseconds: 200_000_000)
 
+            guard !Task.isCancelled else { return }
             await select(candidate)
+
             await MainActor.run {
                 self.decisionIndex += 1
             }
+
+            guard !Task.isCancelled else { return }
             await speakCurrentMatch()
         }
     }
@@ -230,7 +244,9 @@ class TournamentViewModel: ObservableObject {
         connectManager.isTimeout = false
         connectManager.isFirstRequest = true
 
-        decisionTask = Task {
+        decisionTask = Task { [weak self] in
+            guard let self else { return }
+
             connectManager.sendStageDecisionWithFirstTTS(
                 decisionIndex)
             await MainActor.run { self.isTTSPlaying = true }
@@ -253,7 +269,9 @@ class TournamentViewModel: ObservableObject {
             "B. \(b.name)",
         ]
 
-        decisionTask = Task {
+        decisionTask = Task { [weak self] in
+            guard let self else { return }
+
             connectManager.sendStageDecisionWithSecTTS(decisionIndex)
             await MainActor.run { self.isTTSPlaying = true }
             for text in texts {

--- a/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
@@ -27,21 +27,9 @@ class TournamentViewModel: ObservableObject {
         }
     }
     
-    @Published var isFinished = false {
-        didSet {
-            guard isFinished, let context = context else { return }
-            finishTournamentAndSave(context: context)
-        }
-    }
-    
-    @Published var winner: Candidate? {
-        didSet {
-            Task {
-                await handleTournamentEndingTTS()
-            }
-        }
-    }
-    
+    @Published var isFinished = false
+    @Published var winner: Candidate?
+
     private let contentRepository: ContentRepositoryProtocol
     private let historyRepository: PlayHistoryRepositoryProtocol
     private let tournamentId: UUID
@@ -145,6 +133,8 @@ class TournamentViewModel: ObservableObject {
                 winner = nextRoundCandidates.first
                 isFinished = true
                 currentCandidates = nil
+                if let context { finishTournamentAndSave(context: context) }
+                Task { await handleTournamentEndingTTS() }
             } else {
                 // 다음 라운드 준비
                 rounds.append(nextRoundCandidates)

--- a/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
@@ -72,18 +72,23 @@ class TournamentViewModel: ObservableObject {
         historyRepository: PlayHistoryRepositoryProtocol =
             PlayHistoryRepository()
     ) {
-        self.tournament = content.tournament
-        self.tournamentId = content.tournament!.id
+        guard let tournament = content.tournament else {
+            Log.fault("TournamentViewModel 초기화 실패 — content.tournament가 nil")
+            fatalError("[FATAL] TournamentViewModel 초기화 실패 — content.tournament가 nil")
+        }
+        self.tournament = tournament
+        self.tournamentId = tournament.id
         self.contentRepository = contentRepository
         self.historyRepository = historyRepository
         self.title = content.title
 
         connectManager.$selectedOption
             .receive(on: DispatchQueue.main)
-            .sink { newValue in
-                guard let option = newValue,
-                    let (a, b) = self.currentCandidates,
-                    self.selectedOption == nil
+            .sink { [weak self] newValue in
+                guard let self,
+                      let option = newValue,
+                      let (a, b) = self.currentCandidates,
+                      self.selectedOption == nil
                 else { return }
 
                 self.decisionTask?.cancel()
@@ -97,13 +102,12 @@ class TournamentViewModel: ObservableObject {
 
         connectManager.$isTimeout
             .receive(on: DispatchQueue.main)
-            .sink { newValue in
-                self.handleTimeout(newValue)
+            .sink { [weak self] newValue in
+                self?.handleTimeout(newValue)
             }
             .store(in: &cancellable)
-
     }
-    
+
     func setContext(_ context: ModelContext) {
         self.context = context
     }

--- a/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
@@ -185,11 +185,11 @@ class TournamentViewModel: ObservableObject {
     }
 
     func finishTournamentAndSave(context: ModelContext) {
-        guard let winner = winner else { return }
+        guard let winner = winner, let tournament = tournament else { return }
         do {
             try historyRepository.saveTournamentHistory(
                 context: context,
-                tournament: tournament!,
+                tournament: tournament,
                 winner: winner,
                 matchHistory: matchHistory
             )

--- a/Kartrider/Sources/Utility/Managers/TTSManager.swift
+++ b/Kartrider/Sources/Utility/Managers/TTSManager.swift
@@ -21,6 +21,14 @@ final class TTSManager: NSObject, @unchecked Sendable, ObservableObject {
         synthesizer.delegate = self
     }
 
+    deinit {
+        Log.debug("TTSManager deinit")
+        synthesizer.stopSpeaking(at: .immediate)
+        synthesizer.delegate = nil
+        currentContinuation?.resume()
+        currentContinuation = nil
+    }
+
     // TODO: 전체적인 개선이 필요해 보임
     func speakSequentially(_ text: String) async {
         print("[INFO] speakSequentially 호출")
@@ -28,6 +36,10 @@ final class TTSManager: NSObject, @unchecked Sendable, ObservableObject {
         guard !Task.isCancelled else { return }
 
         while await self.state == .paused {
+            guard !Task.isCancelled else {
+                print("[DEBUG] [speakSequentially] 일시정지 상태에서 중단")
+                return
+            }
             print("[DEBUG] [speakSequentially] 일시정지 상태, 대기 중...")
             try? await Task.sleep(for: .milliseconds(100))
         }
@@ -38,6 +50,11 @@ final class TTSManager: NSObject, @unchecked Sendable, ObservableObject {
             return
         }
 
+        guard !Task.isCancelled else {
+            print("[DEBUG] 중단")
+            return
+        }
+        
         await MainActor.run {
             self.state = .playing
         }

--- a/Kartrider/Sources/Utility/Managers/TTSManager.swift
+++ b/Kartrider/Sources/Utility/Managers/TTSManager.swift
@@ -25,6 +25,8 @@ final class TTSManager: NSObject, @unchecked Sendable, ObservableObject {
     func speakSequentially(_ text: String) async {
         print("[INFO] speakSequentially 호출")
 
+        guard !Task.isCancelled else { return }
+
         while await self.state == .paused {
             print("[DEBUG] [speakSequentially] 일시정지 상태, 대기 중...")
             try? await Task.sleep(for: .milliseconds(100))


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

close #93 

## ✨ What’s this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

#### 문제점
- TTSManager와 ViewModel이 완전히 해제되지 않아 메모리 누수 발생
- 선택지 선택 후 뒤로가기 눌러도 백그라운드에서 TTS Task가 계속 실행됨
- Task가 ViewModel을 강하게 캡처해서 순환 참조 발생

#### 개선 (땜빵)
- combine sink에 weak self 사용
- 모든 비동기 Task에 weak self 사용
- Task 생명주기 관리 → StoryViewModel과 TournamentViewModel에 각각 nodeHandlingTask, selectionTask를 추가
- Task 내부 취소 체크 추가

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] TTS 정상 종료

---

TournamentViewModel을 예로 들어서 설명하면,

기존에는 handleSelction 함수에 Task가 있지만 어디에도 저장되지 않는 **익명의 Task**가 있었습니다.

```swift
// TournamentViewModel.swift
func handleSelection(_ candidate: Candidate) {
    Task {  // → 뭔지 알길이 없음
        ttsManager.stop()
        await speakSelectedChoice(candidate)
        try? await Task.sleep(nanoseconds: 200_000_000)
        await select(candidate)
        await speakCurrentMatch()  // ← 근데 여기서 다음 선택지 TTS 재생하네?
    }
}
```

**문제 상황:**
사용자가 선택지 A를 선택하고 TTS가 재생되는 중에 뒤로가기 버튼을 누르면:
1. `cleanup()` 함수 호출됨
2. `ttsManager.stop()` 호출됨
3. **하지만 익명 Task는 여전히 백그라운드에서 실행 중**
4. Task가 `speakCurrentMatch()`에 도달하여 다음 선택지 TTS가 재생됨

**해결:**
익명 Task에 **이름(변수)을 붙여서** 제어 가능하게 만들었습니다.

이제 뒤로가기 버튼을 누르면:
1. `cleanup()` 호출
2. `selectionTask.cancel()` 실행 → Task의 `isCancelled` 플래그가 true로 변경
3. Task가 다음 `await` 지점에서 `guard !Task.isCancelled` 체크
4. 즉시 `return`으로 종료 → `speakCurrentMatch()` 실행 안 됨

***하지만 이것은 땜빵일 뿐. TTS 상태 관리를 좀 잘 해볼 필요가 있겠스빈다***