### PR TITLE
♻️ Refactor: #98 StoryViewModel, TournamentViewModel 코드 정리

### DIFF
--- a/Kartrider/Sources/Feature/Story/StoryView.swift
+++ b/Kartrider/Sources/Feature/Story/StoryView.swift
@@ -74,7 +74,7 @@ struct StoryView: View {
             Task {
                 await MainActor.run { storyViewModel.isSequenceInProgress = true }
                 try? await Task.sleep(for: .milliseconds(300))
-                await storyViewModel.handleStoryNode(storyNode)
+                await storyViewModel.processNode(storyNode)
             }
         }
     }

--- a/Kartrider/Sources/Feature/Story/StoryViewModel.swift
+++ b/Kartrider/Sources/Feature/Story/StoryViewModel.swift
@@ -1,48 +1,52 @@
-import Combine
-
 //
 //  StoryViewModel.swift
 //  Kartrider
 //
 //  Created by J on 5/31/25.
 //
+
+import Combine
 import Foundation
 import SwiftData
 
 class StoryViewModel: ObservableObject {
+    // MARK: - Properties
 
+    // 외부 의존성
     let connectManager = IosConnectManager.shared
+    var ttsManager = TTSManager()
+
+    // Repository
     private var contentRepository: ContentRepositoryProtocol?
     private var historyRepository: PlayHistoryRepositoryProtocol?
 
+    // Combine
     private var cancellable = Set<AnyCancellable>()
+    private var decisionTask: Task<Void, Never>?
+    private var nodeHandlingTask: Task<Void, Never>?
 
+    // 컨텐츠 정보
     let content: ContentMeta
     let startNodeId: String
-    private var stepHistory: [StoryStepData] = []
-    private var lastToggleTime: Date = .distantPast
+
+    // 내부 상태
+    private var recordedSteps: [StoryStepData] = []
+    private var isSecondDecisionPlayed = false
+
+    // MARK: - Published
 
     @Published var isLoading: Bool = true
     @Published var errorMessage: String?
     @Published var currentNode: StoryNode?
     @Published var isSequenceInProgress = false
     @Published var selectedPath: [StoryChoiceOption] = []
-    @Published var endingId: String = ""
+    @Published var currentEndingId: String = ""
+    @Published var decisionIndex = 0
     @Published var isTTSPlaying = false
     @Published var isTogglingTTS = false
     @Published var isTransitioningTTS = false
 
-    @Published var decisionIndex = 0
-    private var secPlayed = false
-    private var decisionTask: Task<Void, Never>?
-    private var nodeHandlingTask: Task<Void, Never>?
-
-    var ttsManager = TTSManager()
-
-    func configure(context: ModelContext) {
-        contentRepository = ContentRepository(context: context)
-        historyRepository = PlayHistoryRepository(context: context)
-    }
+    // MARK: - Init
 
     init(content: ContentMeta) {
         self.content = content
@@ -88,6 +92,15 @@ class StoryViewModel: ObservableObject {
             .store(in: &cancellable)
     }
 
+    // MARK: - Setup
+
+    func configure(context: ModelContext) {
+        contentRepository = ContentRepository(context: context)
+        historyRepository = PlayHistoryRepository(context: context)
+    }
+
+    // MARK: - LifeCycle
+
     deinit {
         decisionTask?.cancel()
         nodeHandlingTask?.cancel()
@@ -104,6 +117,8 @@ class StoryViewModel: ObservableObject {
         ttsManager.stop()
     }
 
+    // MARK: - Node Navigation
+
     @MainActor
     func loadInitialNode() async {
         isLoading = true
@@ -114,7 +129,7 @@ class StoryViewModel: ObservableObject {
                let node = story.nodes.first(where: { $0.id == startNodeId })
             {
                 currentNode = node
-                await handleStoryNode(node)
+                await processNode(node)
             } else {
                 errorMessage = "해당 스토리를 찾을 수 없습니다"
             }
@@ -145,7 +160,7 @@ class StoryViewModel: ObservableObject {
         else { return }
 
         let selectedChoice: StoryChoiceOption
-        var selectedText: String = ""
+        var selectedText = ""
 
         if let choice = currentNode.choiceA, choice.toId == toId {
             selectedPath.append(.a)
@@ -159,7 +174,7 @@ class StoryViewModel: ObservableObject {
             return
         }
 
-        stepHistory.append(StoryStepData(
+        recordedSteps.append(StoryStepData(
             nodeId: currentNode.id,
             type: currentNode.type,
             nodeText: currentNode.text,
@@ -169,11 +184,11 @@ class StoryViewModel: ObservableObject {
         ))
 
         self.currentNode = nextNode
-        self.decisionIndex += 1
+        decisionIndex += 1
     }
 
     @MainActor
-    func handleStoryNode(_ node: StoryNode) async {
+    func processNode(_ node: StoryNode) async {
         nodeHandlingTask?.cancel()
 
         nodeHandlingTask = Task { [weak self] in
@@ -185,16 +200,16 @@ class StoryViewModel: ObservableObject {
                 guard !Task.isCancelled else { return }
                 connectManager.isTimeout = false
                 connectManager.isFirstRequest = true
-                secPlayed = false
-                firstDecision(node: node)
+                isSecondDecisionPlayed = false
+                speakFirstDecision(node: node)
 
             } else if node.nextId == nil {
                 guard !Task.isCancelled else { return }
-                endingId = checkEndingCondition()
-                await goToEndingNode(toId: endingId)
+                currentEndingId = resolveEndingId()
+                await loadEndingNode(toId: currentEndingId)
 
             } else if node.type == .exposition {
-                stepHistory.append(StoryStepData(
+                recordedSteps.append(StoryStepData(
                     nodeId: node.id,
                     type: node.type,
                     nodeText: node.text,
@@ -204,14 +219,14 @@ class StoryViewModel: ObservableObject {
                 ))
                 connectManager.sendStageExpositionWithResume()
                 await ttsManager.speakSequentially(node.text)
-                self.goToNextNode(from: node)
+                goToNextNode(from: node)
             }
 
             isSequenceInProgress = false
         }
     }
 
-    private func checkEndingCondition() -> String {
+    private func resolveEndingId() -> String {
         guard let story = currentNode?.story else { return "" }
 
         for condition in story.endingConditions {
@@ -224,14 +239,14 @@ class StoryViewModel: ObservableObject {
     }
 
     @MainActor
-    private func goToEndingNode(toId: String) async {
+    private func loadEndingNode(toId: String) async {
         isLoading = true
         do {
             if let storyId = content.story?.id,
                let story = try contentRepository?.fetchStory(by: storyId),
                let endingNode = story.nodes.first(where: { $0.id == toId })
             {
-                stepHistory.append(StoryStepData(
+                recordedSteps.append(StoryStepData(
                     nodeId: endingNode.id,
                     type: endingNode.type,
                     nodeText: endingNode.text,
@@ -243,7 +258,7 @@ class StoryViewModel: ObservableObject {
                 if let endingIndex = endingNode.endingIndex {
                     try historyRepository?.saveStoryHistory(
                         content: content,
-                        steps: stepHistory,
+                        steps: recordedSteps,
                         endingIndex: endingIndex
                     )
                 }
@@ -262,6 +277,68 @@ class StoryViewModel: ObservableObject {
         }
         isLoading = false
     }
+
+    // MARK: - Decision
+
+    func speakFirstDecision(node: StoryNode) {
+        decisionTask?.cancel()
+        decisionTask = Task { [weak self] in
+            guard let self else { return }
+
+            connectManager.sendStageDecisionWithFirstTTS(decisionIndex)
+            if !node.text.isEmpty {
+                await ttsManager.speakSequentially(node.text)
+            }
+            await ttsManager.speakSequentially("A")
+            await ttsManager.speakSequentially(node.choiceA?.text ?? "")
+            await ttsManager.speakSequentially("B")
+            await ttsManager.speakSequentially(node.choiceB?.text ?? "")
+
+            connectManager.sendStageDecisionWithFirstTimer(decisionIndex)
+        }
+    }
+
+    func speakSecondDecision(node: StoryNode) {
+        decisionTask?.cancel()
+        isSecondDecisionPlayed = true
+
+        let texts = [
+            "선택지가 다시 한번 재생됩니다",
+            "A. \(node.choiceA?.text ?? "")",
+            "B. \(node.choiceB?.text ?? "")",
+        ]
+
+        decisionTask = Task { [weak self] in
+            guard let self else { return }
+
+            isSecondDecisionPlayed = true
+            connectManager.sendStageDecisionWithSecTTS(decisionIndex)
+            for text in texts {
+                await ttsManager.speakSequentially(text)
+            }
+            connectManager.sendStageDecisionWithSecTimer(decisionIndex)
+        }
+    }
+
+    func handleTimeout(_ newValue: Bool?) {
+        let isTimeout = newValue == true
+        let noSelection = connectManager.selectedOption == nil
+        guard isTimeout, noSelection,
+              let node = currentNode, node.type == .decision
+        else { return }
+
+        if connectManager.isFirstRequest == true {
+            speakSecondDecision(node: node)
+            connectManager.isFirstRequest = false
+        } else {
+            if let toId = node.choiceA?.toId {
+                selectChoice(toId: toId)
+            }
+        }
+        connectManager.isTimeout = false
+    }
+
+    // MARK: - TTS
 
     func toggleSpeaking() {
         if isTogglingTTS {
@@ -282,6 +359,8 @@ class StoryViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Watch
+
     func handleWatchChoice(option: StoryChoiceOption) {
         guard let currentNode else { return }
         connectManager.sendChoiceInterrupt()
@@ -297,63 +376,5 @@ class StoryViewModel: ObservableObject {
                 selectChoice(toId: toId)
             }
         }
-    }
-
-    func firstDecision(node: StoryNode) {
-        decisionTask?.cancel()
-        decisionTask = Task { [weak self] in
-            guard let self else { return }
-
-            connectManager.sendStageDecisionWithFirstTTS(decisionIndex)
-            if !node.text.isEmpty {
-                await ttsManager.speakSequentially(node.text)
-            }
-            await ttsManager.speakSequentially("A")
-            await ttsManager.speakSequentially(node.choiceA?.text ?? "")
-            await ttsManager.speakSequentially("B")
-            await ttsManager.speakSequentially(node.choiceB?.text ?? "")
-
-            connectManager.sendStageDecisionWithFirstTimer(decisionIndex)
-        }
-    }
-
-    func playSecDecisionTTS(node: StoryNode) {
-        decisionTask?.cancel()
-        secPlayed = true
-
-        let texts = [
-            "선택지가 다시 한번 재생됩니다",
-            "A. \(node.choiceA?.text ?? "")",
-            "B. \(node.choiceB?.text ?? "")",
-        ]
-
-        decisionTask = Task { [weak self] in
-            guard let self else { return }
-
-            secPlayed = true
-            connectManager.sendStageDecisionWithSecTTS(decisionIndex)
-            for text in texts {
-                await ttsManager.speakSequentially(text)
-            }
-            connectManager.sendStageDecisionWithSecTimer(decisionIndex)
-        }
-    }
-
-    func handleTimeout(_ newValue: Bool?) {
-        let isTimeout = newValue == true
-        let noSelection = connectManager.selectedOption == nil
-        guard isTimeout, noSelection,
-              let node = currentNode, node.type == .decision
-        else { return }
-
-        if connectManager.isFirstRequest == true {
-            playSecDecisionTTS(node: node)
-            connectManager.isFirstRequest = false
-        } else {
-            if let toId = node.choiceA?.toId {
-                selectChoice(toId: toId)
-            }
-        }
-        connectManager.isTimeout = false
     }
 }

--- a/Kartrider/Sources/Feature/Story/StoryViewModel.swift
+++ b/Kartrider/Sources/Feature/Story/StoryViewModel.swift
@@ -52,12 +52,16 @@ class StoryViewModel: ObservableObject {
         self.content = content
         startNodeId = content.story?.startNodeId ?? ""
 
-        ttsManager.didSpeakingStateChanged = { [weak self] speaking in
-            DispatchQueue.main.async {
-                self?.isTTSPlaying = speaking
-                self?.isTogglingTTS = false
+        ttsManager.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                isTTSPlaying = (state == .playing)
+                if state == .inactive || state == .paused {
+                    isTogglingTTS = false
+                }
             }
-        }
+            .store(in: &cancellable)
 
         connectManager.$isTTSPlaying
             .receive(on: DispatchQueue.main)
@@ -217,7 +221,7 @@ class StoryViewModel: ObservableObject {
                     selectedText: nil,
                     timestamp: Date()
                 ))
-                connectManager.sendStageExpositionWithResume()
+                connectManager.sendStageExposition(isTTSPlaying: true)
                 await ttsManager.speakSequentially(node.text)
                 goToNextNode(from: node)
             }
@@ -264,11 +268,11 @@ class StoryViewModel: ObservableObject {
                 }
 
                 currentNode = endingNode
-                connectManager.sendStageEndingTTS()
+                connectManager.sendStageEnding(isTimerRunning: false)
                 if !endingNode.text.isEmpty {
                     await ttsManager.speakSequentially(endingNode.text)
                 }
-                connectManager.sendStageEndingTimer()
+                connectManager.sendStageEnding(isTimerRunning: true)
             } else {
                 errorMessage = "해당 결말을 찾을 수 없습니다"
             }
@@ -285,7 +289,8 @@ class StoryViewModel: ObservableObject {
         decisionTask = Task { [weak self] in
             guard let self else { return }
 
-            connectManager.sendStageDecisionWithFirstTTS(decisionIndex)
+            connectManager.sendStageDecision(decisionIndex: decisionIndex, isTimerRunning: false, isFirstRequest: true)
+
             if !node.text.isEmpty {
                 await ttsManager.speakSequentially(node.text)
             }
@@ -294,7 +299,7 @@ class StoryViewModel: ObservableObject {
             await ttsManager.speakSequentially("B")
             await ttsManager.speakSequentially(node.choiceB?.text ?? "")
 
-            connectManager.sendStageDecisionWithFirstTimer(decisionIndex)
+            connectManager.sendStageDecision(decisionIndex: decisionIndex, isTimerRunning: true, isFirstRequest: true)
         }
     }
 
@@ -312,11 +317,11 @@ class StoryViewModel: ObservableObject {
             guard let self else { return }
 
             isSecondDecisionPlayed = true
-            connectManager.sendStageDecisionWithSecTTS(decisionIndex)
+            connectManager.sendStageDecision(decisionIndex: decisionIndex, isTimerRunning: false, isFirstRequest: false)
             for text in texts {
                 await ttsManager.speakSequentially(text)
             }
-            connectManager.sendStageDecisionWithSecTimer(decisionIndex)
+            connectManager.sendStageDecision(decisionIndex: decisionIndex, isTimerRunning: true, isFirstRequest: false)
         }
     }
 
@@ -348,9 +353,9 @@ class StoryViewModel: ObservableObject {
         isTogglingTTS = true
 
         if isTTSPlaying {
-            connectManager.sendStageExpositionWithPause()
+            connectManager.sendStageExposition(isTTSPlaying: false)
         } else {
-            connectManager.sendStageExpositionWithResume()
+            connectManager.sendStageExposition(isTTSPlaying: true)
         }
 
         ttsManager.toggleSpeaking()

--- a/Kartrider/Sources/Feature/Tournament/TournamentView.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentView.swift
@@ -43,15 +43,23 @@ struct TournamentView: View {
                         b: secondCandiate.name,
                         onSelectA: {
                             tournamentViewModel.selectedOption = .a
-                            tournamentViewModel.handleSelection(firstCandidate)
+                            tournamentViewModel.processSelection(firstCandidate)
                         },
                         onSelectB: {
                             tournamentViewModel.selectedOption = .b
-                            tournamentViewModel.handleSelection(secondCandiate)
+                            tournamentViewModel.processSelection(secondCandiate)
                         },
                         buttonDisabled: tournamentViewModel.isTTSPlaying,
                         selectedOption: tournamentViewModel.selectedOption
                     )
+                    
+                    Spacer()
+
+                    TTSControlButton(
+                        isSpeaking: tournamentViewModel.isTTSPlaying
+                    ) {
+                        tournamentViewModel.toggleSpeaking()
+                    }
                 } else {
                     ProgressView()
                 }
@@ -61,7 +69,7 @@ struct TournamentView: View {
         .task {
             tournamentViewModel.configure(context: context)
             tournamentViewModel.loadTournament()
-            tournamentViewModel.speakCurrentMatch()
+            tournamentViewModel.speakMatchIntro()
         }
     }
 }

--- a/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
@@ -79,7 +79,14 @@ class TournamentViewModel: ObservableObject {
             Log.fault("TournamentViewModel 초기화 실패 — content.tournament가 nil")
             return
         }
-        
+
+        ttsManager.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                self?.isTTSPlaying = (state == .playing)
+            }
+            .store(in: &cancellable)
+
         connectManager.$selectedOption
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newValue in
@@ -200,10 +207,6 @@ class TournamentViewModel: ObservableObject {
         selectedOption = nil
     }
 
-    private func makeNextRound(from round: [Candidate]) -> [Candidate] {
-        round
-    }
-
     // MARK: - Selection
 
     func processSelection(_ candidate: Candidate) {
@@ -267,15 +270,11 @@ class TournamentViewModel: ObservableObject {
         decisionTask = Task { [weak self] in
             guard let self else { return }
 
-            connectManager.sendStageDecisionWithFirstTTS(
-                decisionIndex)
-            await MainActor.run { self.isTTSPlaying = true }
+            connectManager.sendStageDecision(decisionIndex: decisionIndex, isTimerRunning: false, isFirstRequest: true)
             await ttsManager.speakSequentially(currentRoundDescription)
             await ttsManager.speakSequentially("A. \(a.name)")
             await ttsManager.speakSequentially("B. \(b.name)")
-            await MainActor.run { self.isTTSPlaying = false }
-            connectManager.sendStageDecisionWithFirstTimer(
-                decisionIndex)
+            connectManager.sendStageDecision(decisionIndex: decisionIndex, isTimerRunning: true, isFirstRequest: true)
         }
     }
 
@@ -292,13 +291,11 @@ class TournamentViewModel: ObservableObject {
         decisionTask = Task { [weak self] in
             guard let self else { return }
 
-            connectManager.sendStageDecisionWithSecTTS(decisionIndex)
-            await MainActor.run { self.isTTSPlaying = true }
+            connectManager.sendStageDecision(decisionIndex: decisionIndex, isTimerRunning: false, isFirstRequest: false)
             for text in texts {
                 await ttsManager.speakSequentially(text)
             }
-            await MainActor.run { self.isTTSPlaying = false }
-            connectManager.sendStageDecisionWithSecTimer(decisionIndex)
+            connectManager.sendStageDecision(decisionIndex: decisionIndex, isTimerRunning: true, isFirstRequest: false)
         }
     }
 
@@ -308,16 +305,23 @@ class TournamentViewModel: ObservableObject {
 
     @MainActor
     func speakTournamentEnding() async {
-        connectManager.sendStageEndingTTS()
+        connectManager.sendStageEnding(isTimerRunning: false)
 
         guard let winner else { return }
 
-        isTTSPlaying = true
         ttsManager.stop()
         try? await Task.sleep(nanoseconds: 300_000_000)
         await ttsManager.speakSequentially("최종 우승자는 \(winner.name)입니다")
-        connectManager.sendStageEndingTimer()
-        isTTSPlaying = false
+        connectManager.sendStageEnding(isTimerRunning: true)
+    }
+
+    func toggleSpeaking() {
+        if isTTSPlaying {
+            connectManager.sendStageExposition(isTTSPlaying: false)
+        } else {
+            connectManager.sendStageExposition(isTTSPlaying: true)
+        }
+        ttsManager.toggleSpeaking()
     }
 
     // MARK: - History

--- a/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentViewModel.swift
@@ -10,21 +10,34 @@ import Foundation
 import SwiftData
 
 class TournamentViewModel: ObservableObject {
+
+    // MARK: - Properties
+
+    // 외부 의존성
     let connectManager = IosConnectManager.shared
+    var ttsManager = TTSManager()
 
+    // Repository
+    private var contentRepository: ContentRepositoryProtocol?
+    private var historyRepository: PlayHistoryRepositoryProtocol?
+
+    // Combine
     private var cancellable = Set<AnyCancellable>()
-    private var context: ModelContext?
+    private var decisionTask: Task<Void, Never>?
+    private var selectionTask: Task<Void, Never>?
 
-    @Published var matchHistory: [TournamentStepData] = []
-    @Published var isTTSPlaying = false
-    @Published var title: String
-    @Published var currentCandidates: (Candidate, Candidate)? {
-        didSet {
-            connectManager.selectedOption = nil
-            connectManager.isTimeout = false
-            connectManager.isFirstRequest = true
-        }
-    }
+    // 콘텐츠 정보
+    private let tournamentId: UUID
+    private var tournament: Tournament?
+    let title: String
+
+    // 토너먼트 진행 상태
+    private var rounds: [[Candidate]] = []
+    private var roundIndex = 0
+    private var matchIndex = 0
+    private var roundWinners: [Candidate] = []
+
+    // MARK: - Published
 
     @Published var isFinished = false {
         didSet {
@@ -33,43 +46,40 @@ class TournamentViewModel: ObservableObject {
         }
     }
     @Published var winner: Candidate?
+    @Published var currentCandidates: (Candidate, Candidate)? {
+        didSet {
+            connectManager.selectedOption = nil
+            connectManager.isTimeout = false
+            connectManager.isFirstRequest = true
+        }
+    }
+    @Published var matchHistory: [TournamentStepData] = []
+    @Published var selectedOption: StoryChoiceOption? = nil
+    @Published var decisionIndex = 0
+    @Published var isTTSPlaying = false
 
-    private var contentRepository: ContentRepositoryProtocol?
-    private var historyRepository: PlayHistoryRepositoryProtocol?
-    private let tournamentId: UUID
-    private var tournament: Tournament?
-    private var nextRoundCandidates: [Candidate] = []
-    private var rounds: [[Candidate]] = []
-    private var currentRoundIndex = 0 // 지금 몇 라운드인지 ex. 8강, 4강, 결승
-    private var currentMatchIndex = 0 // 지금 라운드에서 몇번째 매치인지
-    private var selectionTask: Task<Void, Never>?
-
+    // Computed
     var currentRoundDescription: String {
-        guard rounds.indices.contains(currentRoundIndex) else { return "" }
-        let count = rounds[currentRoundIndex].count
+        guard rounds.indices.contains(roundIndex) else { return "" }
+        let count = rounds[roundIndex].count
         let roundText: String = (count == 2) ? "결승" : "\(count)강"
-        let matchNumber = currentMatchIndex + 1
+        let matchNumber = matchIndex + 1
         let totalMatches = count / 2
         return "\(roundText)\n\(totalMatches)개의 경기 중 \(matchNumber)번째 경기"
     }
 
-    @Published var selectedOption: StoryChoiceOption? = nil
-    @Published var decisionIndex = 0
-    @Published var decisionTask: Task<Void, Never>? = nil
+    // MARK: - Init
 
-    var ttsManager = TTSManager()
+    init(content: ContentMeta) {
+        self.title = content.title
+        self.tournamentId = content.tournament?.id ?? UUID()
+        self.tournament = content.tournament
 
-    init(
-        content: ContentMeta,
-    ) {
         guard let tournament = content.tournament else {
             Log.fault("TournamentViewModel 초기화 실패 — content.tournament가 nil")
-            fatalError("[FATAL] TournamentViewModel 초기화 실패 — content.tournament가 nil")
+            return
         }
-        self.tournament = tournament
-        tournamentId = tournament.id
-        title = content.title
-
+        
         connectManager.$selectedOption
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newValue in
@@ -84,7 +94,7 @@ class TournamentViewModel: ObservableObject {
 
                 selectedOption = option
                 let selected = option == .a ? a : b
-                handleSelection(selected)
+                processSelection(selected)
             }
             .store(in: &cancellable)
 
@@ -96,17 +106,21 @@ class TournamentViewModel: ObservableObject {
             .store(in: &cancellable)
     }
 
+    // MARK: Setup
+
+    func configure(context: ModelContext) {
+        contentRepository = ContentRepository(context: context)
+        historyRepository = PlayHistoryRepository(context: context)
+    }
+
+    // MARK: Lifecycle
+
     deinit {
         decisionTask?.cancel()
         selectionTask?.cancel()
         cancellable.removeAll()
         ttsManager.stop()
         Log.info("TournamentViewModel deinit")
-    }
-
-    func configure(context: ModelContext) {
-        contentRepository = ContentRepository(context: context)
-        historyRepository = PlayHistoryRepository(context: context)
     }
 
     func cleanup() {
@@ -116,6 +130,8 @@ class TournamentViewModel: ObservableObject {
         selectionTask = nil
         ttsManager.stop()
     }
+
+    // MARK: - Tournament Flow
 
     @MainActor
     func loadTournament() {
@@ -130,8 +146,8 @@ class TournamentViewModel: ObservableObject {
             rounds = [shuffled]
             isFinished = false
             winner = nil
-            currentRoundIndex = 0
-            currentMatchIndex = 0
+            roundIndex = 0
+            matchIndex = 0
             matchHistory = []
             prepareNextMatch()
         } catch {
@@ -141,28 +157,27 @@ class TournamentViewModel: ObservableObject {
 
     @MainActor
     func prepareNextMatch() {
-        let currentRound = rounds[currentRoundIndex]
-        guard currentMatchIndex * 2 + 1 < currentRound.count else {
+        let currentRound = rounds[roundIndex]
+        guard matchIndex * 2 + 1 < currentRound.count else {
             // 현재 라운드 끝났으면
-            if nextRoundCandidates.count == 1 {
-                winner = nextRoundCandidates.first
+            if roundWinners.count == 1 {
+                winner = roundWinners.first
                 isFinished = true
                 currentCandidates = nil
-                if let context { finishTournamentAndSave() }
-                Task { await handleTournamentEndingTTS() }
+                Task { await speakTournamentEnding() }
             } else {
                 // 다음 라운드 준비
-                rounds.append(nextRoundCandidates)
-                currentRoundIndex += 1
-                currentMatchIndex = 0
-                nextRoundCandidates = []
+                rounds.append(roundWinners)
+                roundIndex += 1
+                matchIndex = 0
+                roundWinners = []
                 prepareNextMatch()
             }
             return
         }
 
-        let a = currentRound[currentMatchIndex * 2]
-        let b = currentRound[currentMatchIndex * 2 + 1]
+        let a = currentRound[matchIndex * 2]
+        let b = currentRound[matchIndex * 2 + 1]
         currentCandidates = (a, b)
     }
 
@@ -171,16 +186,16 @@ class TournamentViewModel: ObservableObject {
         guard let (a, b) = currentCandidates else { return }
 
         let step = TournamentStepData(
-            round: rounds[currentRoundIndex].count,
-            matchIndex: currentMatchIndex,
+            round: rounds[roundIndex].count,
+            matchIndex: matchIndex,
             candidateAText: a.name,
             candidateBText: b.name,
             selectedText: selected.name,
             timestamp: Date()
         )
         matchHistory.append(step)
-        nextRoundCandidates.append(selected)
-        currentMatchIndex += 1
+        roundWinners.append(selected)
+        matchIndex += 1
         prepareNextMatch()
         selectedOption = nil
     }
@@ -189,20 +204,9 @@ class TournamentViewModel: ObservableObject {
         round
     }
 
-    func finishTournamentAndSave() {
-        guard let winner = winner, let tournament = tournament else { return }
-        do {
-            try historyRepository?.saveTournamentHistory(
-                tournament: tournament,
-                winner: winner,
-                matchHistory: matchHistory
-            )
-        } catch {
-            Log.error("토너먼트 히스토리 저장 실패: \(error)")
-        }
-    }
+    // MARK: - Selection
 
-    func handleSelection(_ candidate: Candidate) {
+    func processSelection(_ candidate: Candidate) {
         selectionTask?.cancel()
 
         selectionTask = Task { [weak self] in
@@ -227,12 +231,32 @@ class TournamentViewModel: ObservableObject {
             }
 
             guard !Task.isCancelled else { return }
-            await speakCurrentMatch()
+            await speakMatchIntro()
         }
     }
 
+    func handleTimeout(_ newValue: Bool?) {
+        let isTimeout = newValue == true
+        let sameIndex = connectManager.decisionIndex == decisionIndex
+        let noSelection = selectedOption == nil
+
+        guard isTimeout, sameIndex, noSelection else { return }
+
+        if connectManager.isFirstRequest {
+            speakSecondDecision()
+        } else {
+            if let (aCandidate, _) = currentCandidates {
+                selectedOption = .a
+                processSelection(aCandidate)
+            }
+        }
+        connectManager.isTimeout = false
+    }
+
+    // MARK: - TTS
+
     @MainActor
-    func speakCurrentMatch() {
+    func speakMatchIntro() {
         guard let (a, b) = currentCandidates else { return }
 
         decisionTask?.cancel()
@@ -255,7 +279,7 @@ class TournamentViewModel: ObservableObject {
         }
     }
 
-    func playSecondTTS() {
+    func speakSecondDecision() {
         guard let (a, b) = currentCandidates else { return }
         decisionTask?.cancel()
 
@@ -282,26 +306,8 @@ class TournamentViewModel: ObservableObject {
         await ttsManager.speakSequentially("\(candidate.name) 선택")
     }
 
-    func handleTimeout(_ newValue: Bool?) {
-        let isTimeout = newValue == true
-        let sameIndex = connectManager.decisionIndex == decisionIndex
-        let noSelection = selectedOption == nil
-
-        guard isTimeout, sameIndex, noSelection else { return }
-
-        if connectManager.isFirstRequest {
-            playSecondTTS()
-        } else {
-            if let (aCandidate, _) = currentCandidates {
-                selectedOption = .a
-                handleSelection(aCandidate)
-            }
-        }
-        connectManager.isTimeout = false
-    }
-
     @MainActor
-    func handleTournamentEndingTTS() async {
+    func speakTournamentEnding() async {
         connectManager.sendStageEndingTTS()
 
         guard let winner else { return }
@@ -312,5 +318,20 @@ class TournamentViewModel: ObservableObject {
         await ttsManager.speakSequentially("최종 우승자는 \(winner.name)입니다")
         connectManager.sendStageEndingTimer()
         isTTSPlaying = false
+    }
+
+    // MARK: - History
+
+    func finishTournamentAndSave() {
+        guard let winner = winner, let tournament = tournament else { return }
+        do {
+            try historyRepository?.saveTournamentHistory(
+                tournament: tournament,
+                winner: winner,
+                matchHistory: matchHistory
+            )
+        } catch {
+            Log.error("토너먼트 히스토리 저장 실패: \(error)")
+        }
     }
 }

--- a/Kartrider/Sources/Model/Enums/TTSState.swift
+++ b/Kartrider/Sources/Model/Enums/TTSState.swift
@@ -9,5 +9,4 @@ enum TTSState {
     case inactive
     case playing
     case paused
-    case finished
 }

--- a/Kartrider/Sources/Utility/Managers/IosConnectManager.swift
+++ b/Kartrider/Sources/Utility/Managers/IosConnectManager.swift
@@ -10,11 +10,12 @@ import WatchConnectivity
 
 class IosConnectManager: NSObject, WCSessionDelegate, ObservableObject {
 
+    // MARK: - Properties
+
     static let shared = IosConnectManager()
 
-    var session: WCSession
+    let session: WCSession
 
-    @Published var message: [String: Any] = [:]
     @Published var isTTSPlaying: Bool = true
     @Published var decisionIndex: Int = 0
     @Published var decisionCount: Int = 0
@@ -23,208 +24,104 @@ class IosConnectManager: NSObject, WCSessionDelegate, ObservableObject {
     @Published var isTimeout: Bool? = false
     @Published var isFirstRequest: Bool = true
 
-    private enum messageKey: String {
-        case isTTSPlaying
-        case decisionIndex
-        case decisionCount
-        case selectedChoice
-        case selectedOption
-        case isTimeout
-        case isFirstRequest
-    }
+    // MARK: - Init
 
     private init(session: WCSession = .default) {
         self.session = session
         super.init()
         self.session.delegate = self
-        session.activate()
+        self.session.activate()
     }
 
-    func session(_ session: WCSession, didReceiveMessage message: [String: Any])
-    {
+    // MARK: - Receive
+
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
         DispatchQueue.main.async {
-            if let isTTSPlaying = message[messageKey.isTTSPlaying.rawValue]
-                as? Bool
-            {
-                self.isTTSPlaying = isTTSPlaying
+            guard let decoded = self.decode(message, as: WatchToIosMessage.self) else { return }
+            if let v = decoded.isTTSPlaying { self.isTTSPlaying = v }
+            if let v = decoded.decisionIndex { self.decisionIndex = v }
+            if let v = decoded.decisionCount { self.decisionCount = v }
+            if let v = decoded.isTimeout { self.isTimeout = v }
+            if let v = decoded.isFirstRequest { self.isFirstRequest = v }
+            if let raw = decoded.selectedChoice {
+                self.selectedOption = StoryChoiceOption(rawValue: raw)
             }
-
-            if let decisionIndex = message[messageKey.decisionIndex.rawValue]
-                as? Int
-            {
-                self.decisionIndex = decisionIndex
-            }
-
-            if let decisionCount = message[messageKey.decisionCount.rawValue]
-                as? Int
-            {
-                self.decisionCount = decisionCount
-            }
-
-            if let isTimeout = message[messageKey.isTimeout.rawValue] as? Bool {
-                self.isTimeout = isTimeout
-            }
-
-            if let isFirstRequest = message[messageKey.isFirstRequest.rawValue]
-                as? Bool
-            {
-                self.isFirstRequest = isFirstRequest
-            }
-
-            if let selectedChoiceRaw = message[
-                messageKey.selectedChoice.rawValue] as? String,
-                let selectedChoice = StoryChoiceOption(
-                    rawValue: selectedChoiceRaw)
-            {
-                //                self.selectedOption = nil
-                //                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                self.selectedOption = selectedChoice
-                //                }
-            }
-
         }
     }
 
-    func sendStageIdle() {
-        let message: [String: Any] = [
-            "currentStage": "idle",
-            "hasStartedContent": true,
-        ]
+    // MARK: - Send
 
-        let session = WCSession.default
-        Log.debug("idle message 보내기: \(message)")
+    func sendStageIdle(retryCount: Int = 0) {
+        guard retryCount < 3 else {
+            Log.warning("Watch 연결 실패 — 재시도 횟수 초과")
+            return
+        }
 
-        if session.isReachable {
-            Log.debug("워치로 idle 메시지 전송")
-            session.sendMessage(message, replyHandler: nil)
-        } else {
-            Log.warning("세션 도달 불가. 1초 뒤 재시도.")
+        guard session.isReachable else {
+            Log.warning("세션 도달 불가. 1초 뒤 재시도. (\(retryCount + 1)/3)")
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                self.sendStageIdle()
+                self.sendStageIdle(retryCount: retryCount + 1)
             }
+            return
         }
+
+        Log.debug("워치로 idle 메시지 전송")
+        send(["currentStage": "idle", "hasStartedContent": true])
     }
 
-    func sendStageExpositionWithPause() {
-        let message: [String: Any] = [
-            "currentStage": "exposition",
-            "isTTSPlaying": false,
-        ]
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil)
-        }
-    }
-
-    func sendStageExpositionWithResume() {
-        let message: [String: Any] = [
-            "currentStage": "exposition",
-            "isTTSPlaying": true,
-        ]
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil)
-        }
-    }
-
-    func sendStageDecisionWithFirstTTS(_ decisionIndex: Int) {
-        let message: [String: Any] = [
+    func sendStageDecision(decisionIndex: Int, isTimerRunning: Bool, isFirstRequest: Bool) {
+        send([
             "currentStage": "decision",
-            "isTimerRunning": false,
+            "isTimerRunning": isTimerRunning,
             "decisionIndex": decisionIndex,
-            "isFirstRequest": true,
-        ]
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil)
-        }
+            "isFirstRequest": isFirstRequest,
+        ])
     }
 
-    func sendStageDecisionWithFirstTimer(_ decisionIndex: Int) {
-        let message: [String: Any] = [
-            "currentStage": "decision",
-            "isTimerRunning": true,
-            "decisionIndex": decisionIndex,
-            "isFirstRequest": true,
-        ]
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil)
-        }
+    func sendStageEnding(isTimerRunning: Bool) {
+        send(["currentStage": "ending", "isTimerRunning": isTimerRunning])
     }
 
-    func sendStageDecisionWithSecTTS(_ decisionIndex: Int) {
-        let message: [String: Any] = [
-            "currentStage": "decision",
-            "isTimerRunning": false,
-            "decisionIndex": decisionIndex,
-            "isFirstRequest": false,
-        ]
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil)
-        }
-    }
-
-    func sendStageDecisionWithSecTimer(_ decisionIndex: Int) {
-        let message: [String: Any] = [
-            "currentStage": "decision",
-            "isTimerRunning": true,
-            "decisionIndex": decisionIndex,
-            "isFirstRequest": false,
-        ]
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil)
-        }
+    func sendStageExposition(isTTSPlaying: Bool) {
+        send(["currentStage": "exposition", "isTTSPlaying": isTTSPlaying])
     }
 
     func sendChoiceInterrupt() {
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(
-                [
-                    "currentStage": "decision",
-                    "isInterrupted": true,
-                ], replyHandler: nil)
-        }
+        send(["currentStage": "decision", "isInterrupted": true])
     }
 
-    func sendStageEndingTTS() {
-        let message: [String: Any] = [
-            "currentStage": "ending",
-            "isTimerRunning": false,
-        ]
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil)
-        }
+    // MARK: - Private
+
+    private func send(_ message: [String: Any]) {
+        guard session.isReachable else { return }
+        session.sendMessage(message, replyHandler: nil)
     }
 
-    func sendStageEndingTimer() {
-        let message: [String: Any] = [
-            "currentStage": "ending",
-            "isTimerRunning": true,
-        ]
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil)
-        }
+    private func decode<T: Decodable>(_ message: [String: Any], as type: T.Type) -> T? {
+        guard let data = try? JSONSerialization.data(withJSONObject: message) else { return nil }
+        return try? JSONDecoder().decode(T.self, from: data)
     }
+
+    // MARK: - Session Delegate
 
     func session(
         _ session: WCSession,
         activationDidCompleteWith activationState: WCSessionActivationState,
         error: Error?
-    ) {
+    ) {}
 
-    }
+    func sessionDidBecomeInactive(_ session: WCSession) {}
 
-    func sessionDidBecomeInactive(_ session: WCSession) {
+    func sessionDidDeactivate(_ session: WCSession) {}
+}
 
-    }
+// MARK: - Message Model
 
-    func sessionDidDeactivate(_ session: WCSession) {
-
-    }
+private struct WatchToIosMessage: Decodable {
+    var isTTSPlaying: Bool?
+    var decisionIndex: Int?
+    var decisionCount: Int?
+    var isTimeout: Bool?
+    var isFirstRequest: Bool?
+    var selectedChoice: String?
 }

--- a/Kartrider/Sources/Utility/Managers/TTSManager.swift
+++ b/Kartrider/Sources/Utility/Managers/TTSManager.swift
@@ -12,7 +12,6 @@ final class TTSManager: NSObject, @unchecked Sendable, ObservableObject {
     private var currentContinuation: CheckedContinuation<Void, Never>?
 
     @MainActor @Published private(set) var state: TTSState = .inactive
-    var didSpeakingStateChanged: ((Bool) -> Void)?
 
     private var lastUtteranceText: String?
 
@@ -32,40 +31,26 @@ final class TTSManager: NSObject, @unchecked Sendable, ObservableObject {
     func speakSequentially(_ text: String) async {
         guard !Task.isCancelled else { return }
 
+        // paused면 resume될 때까지 대기
         while await self.state == .paused {
-            guard !Task.isCancelled else {
-                return
-            }
+            guard !Task.isCancelled else { return }
             try? await Task.sleep(for: .milliseconds(100))
         }
 
-        let currentState = await self.state
-        guard currentState == .inactive else {
-            return
-        }
+        guard !Task.isCancelled else { return }
+        guard await self.state == .inactive else { return }
 
-        guard !Task.isCancelled else {
-            return
-        }
-        
-        await MainActor.run {
-            self.state = .playing
-        }
-
+        await MainActor.run { self.state = .playing }
         lastUtteranceText = text
 
         await withCheckedContinuation { [weak self] continuation in
-            guard let self else {
-                continuation.resume()
-                return
-            }
-
+            guard let self else { continuation.resume(); return }
             self.currentContinuation = continuation
             self.speak(text)
         }
     }
 
-    func speak(_ text: String) {
+    private func speak(_ text: String) {
         let utterance = AVSpeechUtterance(string: text)
         utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")
         synthesizer.speak(utterance)
@@ -89,13 +74,10 @@ final class TTSManager: NSObject, @unchecked Sendable, ObservableObject {
 
     func stop() {
         synthesizer.stopSpeaking(at: .immediate)
-
         currentContinuation?.resume()
         currentContinuation = nil
-
         Task { @MainActor in
             self.state = .inactive
-            self.didSpeakingStateChanged?(false)
         }
     }
 
@@ -112,7 +94,6 @@ final class TTSManager: NSObject, @unchecked Sendable, ObservableObject {
                         await self.speakSequentially(last)
                     }
                 }
-            case .finished: break
             }
         }
     }
@@ -122,28 +103,24 @@ extension TTSManager: AVSpeechSynthesizerDelegate {
     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didStart utterance: AVSpeechUtterance) {
         Task { @MainActor in
             self.state = .playing
-            self.didSpeakingStateChanged?(true)
         }
     }
 
     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didPause utterance: AVSpeechUtterance) {
         Task { @MainActor in
             self.state = .paused
-            self.didSpeakingStateChanged?(false)
         }
     }
 
     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didContinue utterance: AVSpeechUtterance) {
         Task { @MainActor in
             self.state = .playing
-            self.didSpeakingStateChanged?(true)
         }
     }
 
     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
         Task { @MainActor in
             self.state = .inactive
-            self.didSpeakingStateChanged?(false)
         }
 
         currentContinuation?.resume()
@@ -153,7 +130,6 @@ extension TTSManager: AVSpeechSynthesizerDelegate {
     func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
         Task { @MainActor in
             self.state = .inactive
-            self.didSpeakingStateChanged?(false)
         }
 
         currentContinuation?.resume()

--- a/Pickacha Watch App/Feature/Story/Decision/DecisionViewModel.swift
+++ b/Pickacha Watch App/Feature/Story/Decision/DecisionViewModel.swift
@@ -174,23 +174,11 @@ class DecisionViewModel: ObservableObject {
         if value > 0.6 {
             self.choice = "B"
             choiceDone()
-            if self.isFirstRequest {
-                self.connectManager.sendFirstChoiceToIos(
-                    self.decisionIndex, "B")
-            } else {
-                self.connectManager.sendSecChoiceToIos(
-                    self.decisionIndex, "B")
-            }
+            connectManager.sendChoiceToIos(decisionIndex, "B", decisionCount: isFirstRequest ? 1 : 2)
         } else if value < -0.6 {
             self.choice = "A"
             choiceDone()
-            if self.isFirstRequest {
-                self.connectManager.sendFirstChoiceToIos(
-                    self.decisionIndex, "A")
-            } else {
-                self.connectManager.sendSecChoiceToIos(
-                    self.decisionIndex, "A")
-            }
+            connectManager.sendChoiceToIos(decisionIndex, "A", decisionCount: isFirstRequest ? 1 : 2)
         }
     }
 

--- a/Pickacha Watch App/Feature/Story/Exposition/ExpositionViewModel.swift
+++ b/Pickacha Watch App/Feature/Story/Exposition/ExpositionViewModel.swift
@@ -27,10 +27,6 @@ class ExpositionViewModel: ObservableObject {
         isTTSPlaying.toggle()
         connectManager.isTTSPlaying = isTTSPlaying
 
-        if isTTSPlaying {
-            connectManager.sendStageExpositionWithResume()
-        } else {
-            connectManager.sendStageExpositionWithPause()
-        }
+        connectManager.sendStageExposition(isTTSPlaying: isTTSPlaying)
     }
 }

--- a/Pickacha Watch App/WatchConnectManager.swift
+++ b/Pickacha Watch App/WatchConnectManager.swift
@@ -10,9 +10,21 @@ import WatchConnectivity
 
 class WatchConnectManager: NSObject, WCSessionDelegate, ObservableObject {
 
+    // MARK: - Properties
+
     static let shared = WatchConnectManager()
 
-    var session: WCSession
+    let session: WCSession
+
+    @Published var currentStage: String = ""
+    @Published var hasStartedContent: Bool = false
+    @Published var isTimerRunning: Bool = false
+    @Published var isTTSPlaying: Bool = true
+    @Published var decisionIndex: Int = 0
+    @Published var isFirstRequest: Bool = false
+    @Published var isInterrupted: Bool = false
+
+    // MARK: - Init
 
     private init(session: WCSession = .default) {
         self.session = session
@@ -25,24 +37,7 @@ class WatchConnectManager: NSObject, WCSessionDelegate, ObservableObject {
         }
     }
 
-    @Published var message: [String: Any] = [:]
-    @Published var currentStage: String = ""
-    @Published var hasStartedContent: Bool = false
-    @Published var isTimerRunning: Bool = false
-    @Published var isTTSPlaying: Bool = true
-    @Published var decisionIndex: Int = 0
-    @Published var isFirstRequest: Bool = false
-    @Published var isInterrupted: Bool = false
-
-    private enum messageKey: String {
-        case currentStage
-        case hasStartedContent
-        case isTimerRunning
-        case isTTSPlaying
-        case decisionIndex
-        case isFirstRequest
-        case isInterrupted
-    }
+    // MARK: - Receive
 
     func session(
         _ session: WCSession,
@@ -52,129 +47,68 @@ class WatchConnectManager: NSObject, WCSessionDelegate, ObservableObject {
         Log.debug("Session activated: \(activationState.rawValue)")
     }
 
-    func session(_ session: WCSession, didReceiveMessage message: [String: Any])
-    {
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
         DispatchQueue.main.async {
             Log.debug("Received message: \(message)")
-            guard let currentStage = message[messageKey.currentStage.rawValue] as? String else { return }
-            
-            Log.debug("stage raw value: '\(currentStage)' (type: \(type(of: currentStage)))")
 
-            if let hasStartedContent = message[
-                messageKey.hasStartedContent.rawValue] as? Bool
-            {
-                self.hasStartedContent = hasStartedContent
-            }
-            if let isTimerRunning = message[messageKey.isTimerRunning.rawValue]
-                as? Bool
-            {
-                self.isTimerRunning = isTimerRunning
-            }
-            if let isTTSPlaying = message[messageKey.isTTSPlaying.rawValue]
-                as? Bool
-            {
-                self.isTTSPlaying = isTTSPlaying
-            }
-            if let decisionIndex = message[messageKey.decisionIndex.rawValue]
-                as? Int
-            {
-                self.decisionIndex = decisionIndex
-            }
-            if let isFirstRequest = message[messageKey.isFirstRequest.rawValue]
-                as? Bool
-            {
-                self.isFirstRequest = isFirstRequest
-            }
-            if let isInterrupted = message[messageKey.isInterrupted.rawValue]
-                as? Bool
-            {
-                self.isInterrupted = isInterrupted
-            }
+            guard let decoded = self.decode(message, as: IosToWatchMessage.self),
+                  let currentStage = decoded.currentStage
+            else { return }
+
+            if let v = decoded.hasStartedContent { self.hasStartedContent = v }
+            if let v = decoded.isTimerRunning { self.isTimerRunning = v }
+            if let v = decoded.isTTSPlaying { self.isTTSPlaying = v }
+            if let v = decoded.decisionIndex { self.decisionIndex = v }
+            if let v = decoded.isFirstRequest { self.isFirstRequest = v }
+            if let v = decoded.isInterrupted { self.isInterrupted = v }
 
             self.currentStage = currentStage
-
-            switch currentStage {
-            case Stage.idle.rawValue:
-                self.message = [
-                    "currentStage": "idle",
-                    "hasStartedContent": self.hasStartedContent,
-                ]
-            case Stage.exposition.rawValue:
-                self.message = [
-                    "currentStage": "exposition",
-                    "isTTSPlaying": self.isTTSPlaying,
-                ]
-            case Stage.decision.rawValue:
-                self.message = [
-                    "currentStage": "decision",
-                    "isTimerRunning": self.isTimerRunning,
-                    "decisionIndex": self.decisionIndex,
-                    "isFirstRequest": self.isFirstRequest,
-                ]
-            case Stage.ending.rawValue:
-                self.message = [
-                    "currentStage": "ending",
-                    "isTimerRunning": self.isTimerRunning,
-                ]
-            default:
-                Log.error("wrong stage: \(currentStage)")
-            }
         }
     }
 
-    func sendStageExpositionWithPause() {
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(["isTTSPlaying": false], replyHandler: nil)
-        }
+    // MARK: - Send
+
+    func sendStageExposition(isTTSPlaying: Bool) {
+        send(["isTTSPlaying": isTTSPlaying])
     }
 
-    func sendStageExpositionWithResume() {
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(["isTTSPlaying": true], replyHandler: nil)
-        }
-    }
-
-    func sendFirstChoiceToIos(_ decisionIndex: Int, _ selectedChoice: String) {
-        let message: [String: Any] = [
+    func sendChoiceToIos(_ decisionIndex: Int, _ selectedChoice: String, decisionCount: Int) {
+        send([
             "decisionIndex": decisionIndex,
             "selectedChoice": selectedChoice,
-            "decisionCount": 1,
-        ]
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil)
-        }
-    }
-
-    func sendSecChoiceToIos(_ decisionIndex: Int, _ selectedChoice: String) {
-        let message: [String: Any] = [
-            "decisionIndex": decisionIndex,
-            "selectedChoice": selectedChoice,
-            "decisionCount": 2,
-        ]
-        let session = WCSession.default
-        if session.isReachable {
-            session.sendMessage(message, replyHandler: nil)
-        }
+            "decisionCount": decisionCount,
+        ])
     }
 
     func sendTimeoutToIos(_ decisionIndex: Int, isFirstRequest: Bool) {
-        let message: [String: Any] = [
+        send([
             "decisionIndex": decisionIndex,
             "isTimeout": true,
             "isFirstRequest": isFirstRequest,
-        ]
+        ])
+    }
+
+    // MARK: - Private
+
+    private func send(_ message: [String: Any]) {
         guard session.isReachable else { return }
         session.sendMessage(message, replyHandler: nil)
     }
 
-    func sendFirstTimeout(_ decisionIndex: Int) {
-        sendTimeoutToIos(decisionIndex, isFirstRequest: true)
+    private func decode<T: Decodable>(_ message: [String: Any], as type: T.Type) -> T? {
+        guard let data = try? JSONSerialization.data(withJSONObject: message) else { return nil }
+        return try? JSONDecoder().decode(T.self, from: data)
     }
+}
 
-    func sendSecondTimeout(_ decisionIndex: Int) {
-        sendTimeoutToIos(decisionIndex, isFirstRequest: false)
-    }
+// MARK: - Message Model
+
+private struct IosToWatchMessage: Decodable {
+    var currentStage: String?
+    var hasStartedContent: Bool?
+    var isTimerRunning: Bool?
+    var isTTSPlaying: Bool?
+    var decisionIndex: Int?
+    var isFirstRequest: Bool?
+    var isInterrupted: Bool?
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

close #98

## ✨ What’s this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

StoryViewModel, TournamentViewModel 코드 정리 및 TTSManager, IosConnectManager, WatchConnectManager 개선을 진행했습니다.

- MARK 그룹핑으로 ViewModel 구역 분리 및 프로퍼티/함수 순서/함수 통합정리
- 변수명/함수명 명확하게 변경
- TTSManager → 불필요한 클로저 제거, @Published로 통일, speakSequentially 일시정지/재개 로직 수정
- TournamentViewModel에 isTTSPlaying TTSManager를 통해서 하도록 변경
- IosConnectManager, WatchConnectManager → send 헬퍼 함수 추가로 중복 제거, Codable 구조체 기반 메시지 파싱
---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
