### PR TITLE
♻️ Refactor: #106 Watch ViewModel 코드 정리 및 메모리 누수 개선

### DIFF
--- a/Pickacha Watch App/Feature/Outro/WatchOutroViewModel.swift
+++ b/Pickacha Watch App/Feature/Outro/WatchOutroViewModel.swift
@@ -11,40 +11,46 @@ import WatchKit
 
 class WatchOutroViewModel: ObservableObject {
 
+    // MARK: - Properties
+
     let connectManager = WatchConnectManager.shared
 
     private var cancellable = Set<AnyCancellable>()
+    private var timer: Timer?
+
+    // MARK: - Published
 
     @Published var time = 10
     @Published var progress: CGFloat = 1.0
     @Published var isTimerRunning = false
-    private var timer: Timer?
+
+    // MARK: - Init
 
     init() {
         connectManager.$isTimerRunning
             .receive(on: DispatchQueue.main)
-            .sink { newValue in
-                if newValue {
-                    self.startTimer()
-                }
-                self.isTimerRunning = newValue
+            .sink { [weak self] newValue in
+                guard let self else { return }
+                isTimerRunning = newValue
+                if newValue { startTimer() }
             }
             .store(in: &cancellable)
     }
 
+    // MARK: - Timer
+
     func startTimer() {
-        guard !isTimerRunning else { return }
+        guard timer == nil else { return }
 
-        isTimerRunning = true
-        connectManager.isTimerRunning = true
-
-        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-            if self.time > 0 {
-                self.time -= 1
-                self.progress = CGFloat(self.time) / 10.0
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            if time > 0 {
+                time -= 1
+                progress = CGFloat(time) / 10.0
                 WKInterfaceDevice.current().play(.start)
             } else {
-                self.timer?.invalidate()
+                timer?.invalidate()
+                timer = nil
             }
         }
     }

--- a/Pickacha Watch App/Feature/Start/WatchStartViewModel.swift
+++ b/Pickacha Watch App/Feature/Start/WatchStartViewModel.swift
@@ -11,12 +11,17 @@ import Foundation
 
 class WatchStartViewModel: ObservableObject {
 
-    let connectManager = WatchConnectManager.shared
+    // MARK: - Properties
 
+    let connectManager = WatchConnectManager.shared
     private let synthesizer = AVSpeechSynthesizer()
     private var cancellable = Set<AnyCancellable>()
 
+    // MARK: - Published
+
     @Published var hasStartedContent = false
+
+    // MARK: - Init
 
     init() {
         connectManager.$hasStartedContent
@@ -25,13 +30,15 @@ class WatchStartViewModel: ObservableObject {
             .store(in: &cancellable)
     }
 
-    func speak(_ text: String) {
-        let utterance = AVSpeechUtterance(string: text)
-        utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-        synthesizer.speak(utterance)
-    }
+    // MARK: - TTS
 
     func speakIntro() {
         speak("이야기를 감상하려면 iPhone에서 앱을 실행해 주세요.")
+    }
+
+    private func speak(_ text: String) {
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")
+        synthesizer.speak(utterance)
     }
 }

--- a/Pickacha Watch App/Feature/Story/Exposition/ExpositionViewModel.swift
+++ b/Pickacha Watch App/Feature/Story/Exposition/ExpositionViewModel.swift
@@ -10,11 +10,16 @@ import Foundation
 
 class ExpositionViewModel: ObservableObject {
 
-    let connectManager = WatchConnectManager.shared
+    // MARK: - Properties
 
+    let connectManager = WatchConnectManager.shared
     private var cancellable = Set<AnyCancellable>()
 
+    // MARK: - Published
+
     @Published var isTTSPlaying = true
+
+    // MARK: - Init
 
     init() {
         connectManager.$isTTSPlaying
@@ -23,10 +28,11 @@ class ExpositionViewModel: ObservableObject {
             .store(in: &cancellable)
     }
 
+    // MARK: - Action
+
     func toggleStateWatch() {
         isTTSPlaying.toggle()
         connectManager.isTTSPlaying = isTTSPlaying
-
         connectManager.sendStageExposition(isTTSPlaying: isTTSPlaying)
     }
 }

--- a/Pickacha Watch App/Feature/Story/WatchStoryViewModel.swift
+++ b/Pickacha Watch App/Feature/Story/WatchStoryViewModel.swift
@@ -10,11 +10,16 @@ import Foundation
 
 class WatchStoryViewModel: ObservableObject {
 
-    let connectManager = WatchConnectManager.shared
+    // MARK: - Properties
 
+    let connectManager = WatchConnectManager.shared
     private var cancellable = Set<AnyCancellable>()
 
+    // MARK: - Published
+
     @Published var currentStage: String = Stage.idle.rawValue
+
+    // MARK: - Init
 
     init() {
         connectManager.$currentStage


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## #️⃣ 관련 이슈
closes #106

## ✨ What’s this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

Watch 앱 ViewModel 코드 품질 개선 및 정리를 진행했습니다.

- DecisionViewModel — Combine 구독 전체에 [weak self] 추가
- DecisionViewModel — 인라인 주석 제거, Timer/Motion/State MARK 그룹핑
- WatchOutroViewModel — connectManager.isTimerRunning 직접 set 제거 (순환 참조 제거)
- WatchOutroViewModel — guard timer == nil으로 중복 타이머 방지
- WatchStartViewModel — speak() private으로 변경, speakIntro()만 노출
- 전체 Watch ViewModel — MARK 그룹핑 추가 (Properties, Published, Init, Action 등)

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 디버깅 코드 및 주석 제거
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성
