### PR TITLE
♻️ Refactor: #107 Preview 정리 및 PreviewHelper 도입

### DIFF
--- a/Kartrider/Preview Content/PreviewHelper.swift
+++ b/Kartrider/Preview Content/PreviewHelper.swift
@@ -1,0 +1,131 @@
+//
+//  PreviewHelper.swift
+//  Kartrider
+//
+//  Created by J on 4/17/26.
+//
+
+import SwiftData
+import SwiftUI
+
+@MainActor
+struct PreviewHelper {
+
+    let container: ModelContainer
+    let context: ModelContext
+
+    init() {
+        let schema = Schema([
+            ContentMeta.self, Story.self, StoryNode.self,
+            StoryChoice.self, EndingCondition.self, Hashtag.self,
+            Tournament.self, Candidate.self, PlayHistory.self,
+            StoryStep.self, TournamentStep.self
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        container = try! ModelContainer(for: schema, configurations: [config])
+        context = container.mainContext
+    }
+
+    // MARK: - ContentMeta
+
+    func makeStoryMeta(
+        title: String = "눈 떠보니 내가 T1 페이커?!",
+        summary: String = "아이언인 내가 페이커 몸에 들어와버렸다.",
+        hashtags: [String] = ["빙의", "LOL"]
+    ) -> ContentMeta {
+        let meta = ContentMeta(
+            title: title,
+            summary: summary,
+            type: .story,
+            hashtags: hashtags.map { Hashtag(value: $0) },
+            thumbnailName: nil
+        )
+        context.insert(meta)
+        return meta
+    }
+
+    func makeTournamentMeta(
+        title: String = "간식 월드컵",
+        summary: String = "가장 좋아하는 간식을 골라보세요!",
+        hashtags: [String] = ["간식", "월드컵"]
+    ) -> ContentMeta {
+        let meta = ContentMeta(
+            title: title,
+            summary: summary,
+            type: .tournament,
+            hashtags: hashtags.map { Hashtag(value: $0) },
+            thumbnailName: nil
+        )
+        context.insert(meta)
+        return meta
+    }
+
+    // MARK: - Story
+
+    @discardableResult
+    func makeStory(meta: ContentMeta) -> Story {
+        let story = Story(startNodeId: "node1", meta: meta)
+        context.insert(story)
+
+        let node1 = StoryNode(id: "node1", text: "지유가 차에 탔다.", type: .exposition, nextId: "node2", story: story)
+        let node2 = StoryNode(id: "node2", text: "말을 걸까, 말까?", type: .decision, story: story)
+        let choiceA = StoryChoice(text: "말을 건다", toId: "end1")
+        let choiceB = StoryChoice(text: "그냥 지나친다", toId: "end1")
+        node2.choiceA = choiceA
+        node2.choiceB = choiceB
+        let ending = StoryNode(id: "end1", text: "결말입니다.", type: .ending, endingIndex: 1, title: "조용한 기다림", story: story)
+
+        let endingConditionA = EndingCondition(pathString: "A", toId: "end1")
+        endingConditionA.story = story
+        let endingConditionB = EndingCondition(pathString: "B", toId: "end1")
+        endingConditionB.story = story
+
+        [node1, node2, ending].forEach { context.insert($0) }
+        context.insert(choiceA)
+        context.insert(choiceB)
+        context.insert(endingConditionA)
+        context.insert(endingConditionB)
+        try? context.save()
+        return story
+    }
+
+    // MARK: - Tournament
+
+    @discardableResult
+    func makeTournament(
+        meta: ContentMeta,
+        candidateNames: [String] = ["아이스크림", "초콜릿", "과자", "젤리"]
+    ) -> Tournament {
+        let tournament = Tournament(meta: meta)
+        context.insert(tournament)
+
+        for name in candidateNames {
+            let candidate = Candidate(name: name, tournament: tournament)
+            context.insert(candidate)
+            tournament.candidates.append(candidate)
+        }
+
+        try? context.save()
+        return tournament
+    }
+
+    // MARK: - PlayHistory
+
+    @discardableResult
+    func makeStoryHistory(meta: ContentMeta, endingIndex: Int = 1) -> PlayHistory {
+        let history = PlayHistory(content: meta)
+        history.endedAt = Date()
+        history.reachedEndingIndex = endingIndex
+        context.insert(history)
+        return history
+    }
+
+    @discardableResult
+    func makeTournamentHistory(meta: ContentMeta, winner: Candidate) -> PlayHistory {
+        let history = PlayHistory(content: meta)
+        history.endedAt = Date()
+        history.winningCandidateId = winner.id
+        context.insert(history)
+        return history
+    }
+}

--- a/Kartrider/Sources/Feature/ContentPlayback /ContentPlaybackView.swift
+++ b/Kartrider/Sources/Feature/ContentPlayback /ContentPlaybackView.swift
@@ -160,78 +160,47 @@ struct ContentPlaybackView: View {
 }
 
 #Preview("스토리") {
-    let schema = Schema([
-        ContentMeta.self, PlayHistory.self, Story.self,
-        StoryNode.self, StoryChoice.self, EndingCondition.self,
-        Tournament.self, Candidate.self, StoryStep.self,
-        TournamentStep.self, Hashtag.self
-    ])
-    let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-    let container = try! ModelContainer(for: schema, configurations: [config])
-    let context = container.mainContext
+    let helper = PreviewHelper()
+    let meta = helper.makeStoryMeta(title: "진격의 거인")
+    helper.makeStory(meta: meta)
+    let history = helper.makeStoryHistory(meta: meta)
 
-    let hashtags = [Hashtag(value: "시대"), Hashtag(value: "장르")]
-    let meta = ContentMeta(
-        title: "진격의 거인",
-        summary: "summary",
-        type: .story,
-        hashtags: hashtags,
-        thumbnailName: nil
+    let step1 = StoryStep(
+        nodeId: "node1",
+        type: .exposition,
+        nodeText: "지유가 차에 탔다.",
+        timestamp: Date(),
+        history: history
     )
-    context.insert(meta)
-
-    let story = Story(startNodeId: "node1", meta: meta)
-    context.insert(story)
-
-    let node1 = StoryNode(id: "node1", text: "지유 (차에 타며)\n\"어... 혹시... 현우 선배 아니에요?\"", type: .exposition, nextId: "node2", story: story)
-    let node2 = StoryNode(id: "node2", text: "말할까, 말까?", type: .decision, story: story)
-    let ending = StoryNode(id: "end1", text: "에렌 예거는 인류를 위협하는 마레 제국과 싸웠다.", type: .ending, endingIndex: 1, title: "조용한 기다림", story: story)
-    [node1, node2, ending].forEach { context.insert($0) }
-
-    let history = PlayHistory(content: meta)
-    history.endedAt = Date()
-    history.reachedEndingIndex = 1
-    context.insert(history)
-
-    let step1 = StoryStep(nodeId: "node1", type: .exposition, nodeText: node1.text, timestamp: Date(), history: history)
-    let step2 = StoryStep(nodeId: "node2", type: .decision, nodeText: node2.text, selectedChoice: .b, selectedText: "어디 가세요?", timestamp: Date(), history: history)
-    [step1, step2].forEach { _ in context.insert(step2) }
+    let step2 = StoryStep(
+        nodeId: "node2",
+        type: .decision,
+        nodeText: "말을 걸까, 말까?",
+        selectedChoice: .b,
+        selectedText: "어디 가세요?",
+        timestamp: Date(),
+        history: history
+    )
+    [step1, step2].forEach { helper.context.insert($0) }
+    try? helper.context.save()
 
     return ContentPlaybackView(history: history)
-        .modelContainer(container)
+        .modelContainer(helper.container)
         .environmentObject(NavigationCoordinator())
 }
 
 #Preview("토너먼트") {
-    let schema = Schema([
-        ContentMeta.self, PlayHistory.self, Story.self,
-        StoryNode.self, StoryChoice.self, EndingCondition.self,
-        Tournament.self, Candidate.self, StoryStep.self,
-        TournamentStep.self, Hashtag.self
-    ])
-    let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-    let container = try! ModelContainer(for: schema, configurations: [config])
-    let context = container.mainContext
+    let helper = PreviewHelper()
+    let meta = helper.makeTournamentMeta(title: "간식 월드컵")
+    let tournament = helper.makeTournament(meta: meta)
+    try? helper.context.save()
 
-    let meta = ContentMeta(
-        title: "간식 월드컵 게임",
-        summary: "summary",
-        type: .tournament,
-        hashtags: [],
-        thumbnailName: nil
-    )
-    context.insert(meta)
+    // save 후 candidates 다시 확인
+    guard let winner = tournament.candidates.first else {
+        return Text("candidates 없음")
+    }
 
-    let tournament = Tournament(meta: meta)
-    context.insert(tournament)
-
-    let winner = Candidate(name: "아이스크림", tournament: tournament)
-    context.insert(winner)
-
-    let history = PlayHistory(content: meta)
-    history.endedAt = Date()
-    history.winningCandidateId = winner.id
-    context.insert(history)
+    let history = helper.makeTournamentHistory(meta: meta, winner: winner)
 
     for i in 1...10 {
         let step = TournamentStep(
@@ -239,14 +208,15 @@ struct ContentPlaybackView: View {
             matchIndex: i - 1,
             candidateAText: "후보 A",
             candidateBText: "후보 B",
-            selectedText: "아이스크림",
+            selectedText: winner.name,
             timestamp: Date(),
             history: history
         )
-        context.insert(step)
+        helper.context.insert(step)
     }
+    try? helper.context.save()
 
     return ContentPlaybackView(history: history)
-        .modelContainer(container)
+        .modelContainer(helper.container)
         .environmentObject(NavigationCoordinator())
 }

--- a/Kartrider/Sources/Feature/ContentSummary/ContentSummaryView.swift
+++ b/Kartrider/Sources/Feature/ContentSummary/ContentSummaryView.swift
@@ -45,6 +45,21 @@ struct ContentSummaryView: View {
 }
 
 #Preview {
-    ContentSummaryView()
+    let helper = PreviewHelper()
+
+    let storyMeta = helper.makeStoryMeta()
+    helper.makeStory(meta: storyMeta)
+    helper.makeStoryHistory(meta: storyMeta)
+
+    let tournamentMeta = helper.makeTournamentMeta()
+    let tournament = helper.makeTournament(meta: tournamentMeta)
+    if let winner = tournament.candidates.first {
+        helper.makeTournamentHistory(meta: tournamentMeta, winner: winner)
+    }
+
+    try? helper.context.save()
+
+    return ContentSummaryView()
+        .modelContainer(helper.container)
         .environmentObject(NavigationCoordinator())
 }

--- a/Kartrider/Sources/Feature/ContentSummary/HistoryRowView.swift
+++ b/Kartrider/Sources/Feature/ContentSummary/HistoryRowView.swift
@@ -69,43 +69,16 @@ struct HistoryRowView: View {
 }
 
 #Preview {
-    let schema = Schema([
-        ContentMeta.self,
-        PlayHistory.self,
-        Story.self,
-        StoryNode.self,
-        StoryChoice.self,
-        EndingCondition.self,
-        Tournament.self,
-        Candidate.self,
-        StoryStep.self,
-        TournamentStep.self,
-        Hashtag.self
-    ])
-    let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-    let container = try! ModelContainer(for: schema, configurations: [config])
-    let context = container.mainContext
-
-    // 목 데이터
-    let hashtags = [Hashtag(value: "시대"), Hashtag(value: "장르"), Hashtag(value: "진격거")]
-    let meta = ContentMeta(
-        title: "진격의 거인",
-        summary: "summary",
-        type: .story,
-        hashtags: hashtags,
-        thumbnailName: nil
-    )
-    context.insert(meta)
-
-    let history = PlayHistory(content: meta)
-    history.endedAt = Date()
-    history.reachedEndingIndex = 1
-    context.insert(history)
+    let helper = PreviewHelper()
+    let meta = helper.makeStoryMeta()
+    helper.makeStory(meta: meta)
+    let history = helper.makeStoryHistory(meta: meta)
+    try? helper.context.save()
 
     return HistoryRowView(
         history: history,
         endingTitle: "조용한 기다림",
         date: "2025.05.28"
     )
-    .modelContainer(container)
+    .modelContainer(helper.container)
 }

--- a/Kartrider/Sources/Feature/Home/HomeView.swift
+++ b/Kartrider/Sources/Feature/Home/HomeView.swift
@@ -44,3 +44,14 @@ struct HomeView: View {
         }
     }
 }
+
+#Preview {
+    let helper = PreviewHelper()
+    helper.makeStory(meta: helper.makeStoryMeta())
+    helper.makeTournament(meta: helper.makeTournamentMeta())
+    try? helper.context.save()
+
+    return HomeView()
+        .modelContainer(helper.container)
+        .environmentObject(NavigationCoordinator())
+}

--- a/Kartrider/Sources/Feature/Intro/IntroView.swift
+++ b/Kartrider/Sources/Feature/Intro/IntroView.swift
@@ -42,19 +42,24 @@ struct IntroView: View {
     }
 }
 
-#Preview {
-    let sample = ContentMeta(
-        title: "눈 떠보니 내가 T1 페이커?!",
-        summary: "2025 월즈가 코 앞인데 아이언인 내가 어느날 눈 떠보니 페이커 몸에 들어와버렸다.",
-        type: .story,
-        hashtags: [
-            Hashtag(value: "빙의"),
-            Hashtag(value: "LOL"),
-            Hashtag(value: "고트")
-        ],
-        thumbnailName: nil
-    )
+#Preview("스토리") {
+    let helper = PreviewHelper()
+    let meta = helper.makeStoryMeta()
+    helper.makeStory(meta: meta)
+    try? helper.context.save()
 
-    return IntroView(content: sample)
+    return IntroView(content: meta)
+        .modelContainer(helper.container)
+        .environmentObject(NavigationCoordinator())
+}
+
+#Preview("토너먼트") {
+    let helper = PreviewHelper()
+    let meta = helper.makeTournamentMeta()
+    helper.makeTournament(meta: meta)
+    try? helper.context.save()
+
+    return IntroView(content: meta)
+        .modelContainer(helper.container)
         .environmentObject(NavigationCoordinator())
 }

--- a/Kartrider/Sources/Feature/Story/StoryView.swift
+++ b/Kartrider/Sources/Feature/Story/StoryView.swift
@@ -78,18 +78,27 @@ struct StoryView: View {
             }
         }
     }
+}
 
-    #Preview {
-        let contentSample = ContentMeta(
-            title: "title sample",
-            summary: "summary sample",
-            type: .story,
-            hashtags: [
-                Hashtag(value: "빙의"),
-                Hashtag(value: "LOL"),
-            ],
-            thumbnailName: nil
-        )
-        StoryView(content: contentSample)
-    }
+#Preview("선택 노드") {
+    let helper = PreviewHelper()
+    let meta = helper.makeStoryMeta()
+    let story = helper.makeStory(meta: meta)
+    try? helper.context.save()
+
+    let node = story.nodes.first(where: { $0.type == .decision })!
+    return DecisionNodeView(
+        storyNode: node,
+        isDisabled: false,
+        selectChoice: { _ in }
+    )
+    .modelContainer(helper.container)
+}
+
+#Preview("결말 노드") {
+    EndingNodeView(title: "조용한 기다림")
+}
+
+#Preview("텍스트 박스") {
+    DescriptionBoxView(text: "지유가 차에 탔다. 현우 선배를 발견했다.")
 }

--- a/Kartrider/Sources/Feature/Tournament/TournamentView.swift
+++ b/Kartrider/Sources/Feature/Tournament/TournamentView.swift
@@ -74,20 +74,20 @@ struct TournamentView: View {
     }
 }
 
-
-#Preview {
-
-    let sample = ContentMeta(
-        title: "눈 떠보니 내가 T1 페이커?!",
-        summary: "2025 월즈가 코 앞인데 아이언인 내가 어느날 눈 떠보니 페이커 몸에 들어와버렸다.",
-        type: .story,
-        hashtags: [
-            Hashtag(value: "빙의"),
-            Hashtag(value: "LOL"),
-            Hashtag(value: "고트")
-        ],
-        thumbnailName: nil
+#Preview("매치") {
+    TournamentMatchView(
+        roundDescription: "4강\n2개의 경기 중 1번째 경기",
+        a: "아이스크림",
+        b: "초콜릿",
+        onSelectA: {},
+        onSelectB: {},
+        buttonDisabled: false,
+        selectedOption: nil
     )
+    .environmentObject(NavigationCoordinator())
+}
 
-    TournamentView(content: sample)
+#Preview("결과") {
+    TournamentResultView(winner: "아이스크림") {}
+        .environmentObject(NavigationCoordinator())
 }

--- a/Kartrider/Sources/Feature/Tournament/View/TournamentMatchView.swift
+++ b/Kartrider/Sources/Feature/Tournament/View/TournamentMatchView.swift
@@ -43,6 +43,15 @@ struct TournamentMatchView: View {
     }
 }
 
-#Preview {
-    TournamentMatchView(roundDescription: "결승\n1번째 경기 중 1번째", a: "젤리", b: "펩시 제로 슈거 라임향", onSelectA: {}, onSelectB: {})
+#Preview("매치") {
+    TournamentMatchView(
+        roundDescription: "4강\n2개의 경기 중 1번째 경기",
+        a: "아이스크림",
+        b: "초콜릿",
+        onSelectA: {},
+        onSelectB: {},
+        buttonDisabled: false,
+        selectedOption: nil
+    )
+    .environmentObject(NavigationCoordinator())
 }

--- a/Kartrider/Sources/Feature/Tournament/View/TournamentResultView.swift
+++ b/Kartrider/Sources/Feature/Tournament/View/TournamentResultView.swift
@@ -29,6 +29,7 @@ struct TournamentResultView: View {
     }
 }
 
-#Preview {
-    TournamentResultView(winner: "아이스크림", onNextTap: {})
+#Preview("결과") {
+    TournamentResultView(winner: "아이스크림") {}
+        .environmentObject(NavigationCoordinator())
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->
## #️⃣ 관련 이슈
closes #107

## ✨ What’s this PR?

### 🧶 주요 변경 내용
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

PreviewHelper를 도입해 Preview 목데이터 생성 로직을 일원화하고 각 화면의 Preview를 정리했습니다.

- PreviewHelper 추가 (Preview Content 폴더) — ModelContainer, 목데이터 생성 함수 일원화
- HomeView, IntroView, ContentSummaryView, ContentPlaybackView, HistoryRowView — PreviewHelper 기반으로 Preview 교체
- StoryView — TTS 없는 컴포넌트 레벨 Preview로 교체 (DecisionNodeView, EndingNodeView, DescriptionBoxView)
- TournamentView — TournamentMatchView, TournamentResultView 컴포넌트 레벨 Preview로 교체

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 컨벤션 확인
- [x] 기능 정상 작동 테스트 완료
- [x] 사용하지 않는 코드/파일 정리
- [x] 작업 내용 및 코드 설명 작성

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

TTS와 충돌을 일으키는지 프리뷰가 안되서 컴포넌트에 적용해놓았음
